### PR TITLE
Add option to attach to existing remote branch

### DIFF
--- a/tmux-new-branch.sh
+++ b/tmux-new-branch.sh
@@ -33,9 +33,33 @@ select_existing_clone() {
     } | fzf --prompt="Select branch: " --height=40% --reverse
 }
 
+# Select from remote branches not yet cloned locally
+select_remote_branch() {
+    local repo_root="$1"
+    local project="$2"
+
+    # Fetch latest from remote
+    git -C "$repo_root" fetch --prune 2>/dev/null
+
+    # Get remote branches, excluding HEAD and already-cloned branches
+    {
+        echo "← Back"
+        git -C "$repo_root" branch -r 2>/dev/null | \
+            grep -v 'HEAD' | \
+            sed 's|origin/||' | \
+            sed 's/^[ *]*//' | \
+            while read branch; do
+                # Exclude branches that already have local clones
+                if [[ ! -d "$ENVS_DIR/${project}-${branch}" ]]; then
+                    echo "$branch"
+                fi
+            done
+    } | fzf --prompt="Select remote branch: " --height=40% --reverse
+}
+
 select_resume_or_new() {
-    printf "← Back\nNo - start new feature/bug\nYes - resume existing" | \
-        fzf --prompt="Resuming existing work? " --height=12% --reverse
+    printf "← Back\nResume - continue existing local clone\nAttach - checkout existing remote branch\nNew - create a new feature branch" | \
+        fzf --prompt="What would you like to do? " --height=16% --reverse
 }
 
 # Main flow with back button support
@@ -68,11 +92,17 @@ main() {
                     continue
                 fi
 
-                if [[ "$RESUME" == "Yes - resume existing" ]]; then
-                    step=3a
-                else
-                    step=3b
-                fi
+                case "$RESUME" in
+                    "Resume - continue existing local clone")
+                        step=3a
+                        ;;
+                    "Attach - checkout existing remote branch")
+                        step=3c
+                        ;;
+                    "New - create a new feature branch")
+                        step=3b
+                        ;;
+                esac
                 ;;
             3a)
                 # Step 3a: Select existing branch for this project
@@ -89,6 +119,49 @@ main() {
 
                 tmux new-window -n "$BRANCH_NAME" -c "$CLONE_DIR"
                 tmux send-keys "claude --resume" Enter
+                exit 0
+                ;;
+            3c)
+                # Step 3c: Select existing remote branch to attach to
+                BRANCH_NAME=$(select_remote_branch "$REPO_ROOT" "$REPO_NAME")
+                if [[ -z "$BRANCH_NAME" ]]; then
+                    exit 0
+                elif [[ "$BRANCH_NAME" == "← Back" ]]; then
+                    step=2
+                    continue
+                fi
+
+                ENV_DIR="${ENVS_DIR}/${REPO_NAME}-${BRANCH_NAME}"
+                CLONE_DIR="${ENV_DIR}/${REPO_NAME}"
+
+                # Get the remote URL from the original repo
+                cd "$REPO_ROOT" || exit 1
+                REMOTE_URL=$(git remote get-url origin 2>/dev/null)
+
+                if [[ -z "$REMOTE_URL" ]]; then
+                    echo "No remote 'origin' found in $REPO_ROOT"
+                    echo "Press enter to close."
+                    read -r
+                    exit 1
+                fi
+
+                # Create env directory and clone
+                mkdir -p "$ENV_DIR"
+                echo "Cloning $REPO_NAME..."
+                git clone "$REMOTE_URL" "$CLONE_DIR" 2>&1
+
+                if [[ $? -ne 0 ]]; then
+                    echo "Failed to clone. Press enter to close."
+                    read -r
+                    rm -rf "$ENV_DIR"
+                    exit 1
+                fi
+
+                cd "$CLONE_DIR" || exit 1
+                git checkout "$BRANCH_NAME" 2>&1
+
+                tmux new-window -n "$BRANCH_NAME" -c "$CLONE_DIR"
+                tmux send-keys "claude" Enter
                 exit 0
                 ;;
             3b)


### PR DESCRIPTION
## Summary
- Adds a third workflow option to checkout an existing remote branch that doesn't have a local clone yet
- Updates menu to show three choices: Resume (local clone), Attach (remote branch), New (create branch)
- New `select_remote_branch()` function fetches and lists remote branches, excluding already-cloned ones

## Test plan
- [ ] Run `./tmux-new-branch.sh` and select a project
- [ ] Verify three options appear: Resume, Attach, New
- [ ] Select "Attach" and verify remote branches are listed (excluding already-cloned ones)
- [ ] Select a remote branch and verify clone is created and branch is checked out
- [ ] Verify tmux window opens with Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)