### PR TITLE
Add project hooks and envs status command

### DIFF
--- a/envs.sh
+++ b/envs.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# envs - Show status of all parallel development environments
+# Usage: envs [options]
+#   -v, --verbose  Show more details (last commit, etc.)
+
+ENVS_DIR="$HOME/code/envs"
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -v|--verbose) VERBOSE=true; shift ;;
+        *) shift ;;
+    esac
+done
+
+if [[ ! -d "$ENVS_DIR" ]]; then
+    echo "No envs directory at $ENVS_DIR"
+    exit 1
+fi
+
+# Header
+printf "%-40s %-25s %s\n" "ENVIRONMENT" "BRANCH" "STATUS"
+printf "%-40s %-25s %s\n" "-----------" "------" "------"
+
+for d in "$ENVS_DIR"/*/; do
+    [[ ! -d "$d" ]] && continue
+
+    env_name=$(basename "$d")
+
+    # Find the git repo inside the env directory
+    repo=$(find "$d" -maxdepth 2 -name ".git" -type d 2>/dev/null | head -1)
+
+    if [[ -z "$repo" ]]; then
+        printf "%-40s %-25s %s\n" "$env_name" "(no git)" "-"
+        continue
+    fi
+
+    dir=$(dirname "$repo")
+    branch=$(git -C "$dir" branch --show-current 2>/dev/null)
+
+    # Count changes
+    staged=$(git -C "$dir" diff --cached --numstat 2>/dev/null | wc -l | tr -d ' ')
+    unstaged=$(git -C "$dir" diff --numstat 2>/dev/null | wc -l | tr -d ' ')
+    untracked=$(git -C "$dir" ls-files --others --exclude-standard 2>/dev/null | wc -l | tr -d ' ')
+
+    # Check for unpushed commits
+    unpushed=$(git -C "$dir" log --oneline @{u}.. 2>/dev/null | wc -l | tr -d ' ')
+
+    # Build status string
+    status=""
+    [[ "$staged" -gt 0 ]] && status+="${staged} staged "
+    [[ "$unstaged" -gt 0 ]] && status+="${unstaged} modified "
+    [[ "$untracked" -gt 0 ]] && status+="${untracked} untracked "
+    [[ "$unpushed" -gt 0 ]] && status+="↑${unpushed} unpushed "
+    [[ -z "$status" ]] && status="clean"
+
+    printf "%-40s %-25s %s\n" "$env_name" "$branch" "$status"
+
+    if $VERBOSE && [[ "$unpushed" -gt 0 ]]; then
+        git -C "$dir" log --oneline @{u}.. 2>/dev/null | sed 's/^/    /'
+    fi
+done

--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,7 @@ fi
 # Make scripts executable
 chmod +x "$SCRIPT_DIR/tmux-new-branch.sh"
 chmod +x "$SCRIPT_DIR/tmux-cleanup-branch.sh"
+chmod +x "$SCRIPT_DIR/envs.sh"
 
 # Create envs directory
 mkdir -p ~/code/envs
@@ -58,3 +59,6 @@ echo "Keybindings:"
 echo "  Ctrl+b c  - Create/resume feature branch"
 echo "  Ctrl+b k  - Cleanup feature branch"
 echo "  Ctrl+b C  - Plain new window"
+echo ""
+echo "Optional: Add this alias to your ~/.zshrc or ~/.bashrc:"
+echo "  alias envs='$SCRIPT_DIR/envs.sh'"

--- a/tmux-cleanup-branch.sh
+++ b/tmux-cleanup-branch.sh
@@ -91,6 +91,12 @@ main() {
                 # Extract branch name from env name (everything after first dash)
                 BRANCH_NAME="${ENV_NAME#*-}"
 
+                # Run teardown hook if it exists
+                if [[ -f "$CLONE_DIR/paraLlm_teardown.sh" ]]; then
+                    echo "Running teardown hook..."
+                    (cd "$CLONE_DIR" && ./paraLlm_teardown.sh)
+                fi
+
                 # Kill any tmux windows with this branch name
                 tmux list-windows -a -F '#{session_name}:#{window_index} #{window_name}' 2>/dev/null | \
                     grep " ${BRANCH_NAME}$" | \

--- a/tmux-new-branch.sh
+++ b/tmux-new-branch.sh
@@ -118,7 +118,12 @@ main() {
                 CLONE_DIR="${ENV_DIR}/${REPO_NAME}"
 
                 tmux new-window -n "$BRANCH_NAME" -c "$CLONE_DIR"
-                tmux send-keys "claude --resume" Enter
+                # Run setup hook if it exists
+                if [[ -f "$CLONE_DIR/paraLlm_setup.sh" ]]; then
+                    tmux send-keys "./paraLlm_setup.sh && claude --resume" Enter
+                else
+                    tmux send-keys "claude --resume" Enter
+                fi
                 exit 0
                 ;;
             3c)
@@ -161,7 +166,12 @@ main() {
                 git checkout "$BRANCH_NAME" 2>&1
 
                 tmux new-window -n "$BRANCH_NAME" -c "$CLONE_DIR"
-                tmux send-keys "claude" Enter
+                # Run setup hook if it exists
+                if [[ -f "$CLONE_DIR/paraLlm_setup.sh" ]]; then
+                    tmux send-keys "./paraLlm_setup.sh && claude" Enter
+                else
+                    tmux send-keys "claude" Enter
+                fi
                 exit 0
                 ;;
             3b)
@@ -185,7 +195,12 @@ main() {
                     echo "Opening existing clone..."
                     sleep 1
                     tmux new-window -n "$BRANCH_NAME" -c "$CLONE_DIR"
-                    tmux send-keys "claude --resume" Enter
+                    # Run setup hook if it exists
+                    if [[ -f "$CLONE_DIR/paraLlm_setup.sh" ]]; then
+                        tmux send-keys "./paraLlm_setup.sh && claude --resume" Enter
+                    else
+                        tmux send-keys "claude --resume" Enter
+                    fi
                     exit 0
                 fi
 
@@ -224,7 +239,12 @@ main() {
                 fi
 
                 tmux new-window -n "$BRANCH_NAME" -c "$CLONE_DIR"
-                tmux send-keys "claude" Enter
+                # Run setup hook if it exists
+                if [[ -f "$CLONE_DIR/paraLlm_setup.sh" ]]; then
+                    tmux send-keys "./paraLlm_setup.sh && claude" Enter
+                else
+                    tmux send-keys "claude" Enter
+                fi
                 exit 0
                 ;;
         esac


### PR DESCRIPTION
## Summary
- Add `paraLlm_setup.sh` / `paraLlm_teardown.sh` hook support for per-project automation
- Add `envs.sh` command to show status of all parallel environments
- Update install script and documentation

## Features

### Project Hooks
Projects can now define optional scripts that run automatically:
- `paraLlm_setup.sh` - runs when creating/resuming an environment (before Claude starts)
- `paraLlm_teardown.sh` - runs when cleaning up an environment (before deletion)

This enables project-specific automation like opening Xcode, running `pod install`, etc.

### Environment Status
New `envs.sh` script shows status of all parallel environments:
```
ENVIRONMENT                              BRANCH                    STATUS
-----------                              ------                    ------
RiffyApp-delta-storage-refactor          delta-storage-refactor    clean
MyProject-bugfix                         bugfix                    ↑3 unpushed
```

## Test plan
- [ ] Create a test project with `paraLlm_setup.sh` that echoes "setup ran"
- [ ] Use Ctrl+b c to create new environment, verify setup runs
- [ ] Use Ctrl+b k to cleanup, verify teardown runs
- [ ] Run `envs.sh` and verify output shows environment status

🤖 Generated with [Claude Code](https://claude.com/claude-code)