### PR TITLE
Auto-close cleanup window and add skip-permissions flag

### DIFF
--- a/tmux-cleanup-branch.sh
+++ b/tmux-cleanup-branch.sh
@@ -116,6 +116,7 @@ main() {
                 fi
 
                 sleep 1
+                tmux kill-window
                 exit 0
                 ;;
         esac

--- a/tmux-new-branch.sh
+++ b/tmux-new-branch.sh
@@ -120,9 +120,9 @@ main() {
                 tmux new-window -n "$BRANCH_NAME" -c "$CLONE_DIR"
                 # Run setup hook if it exists
                 if [[ -f "$CLONE_DIR/paraLlm_setup.sh" ]]; then
-                    tmux send-keys "./paraLlm_setup.sh && claude --resume" Enter
+                    tmux send-keys "./paraLlm_setup.sh && claude --dangerously-skip-permissions --resume" Enter
                 else
-                    tmux send-keys "claude --resume" Enter
+                    tmux send-keys "claude --dangerously-skip-permissions --resume" Enter
                 fi
                 exit 0
                 ;;
@@ -170,7 +170,7 @@ main() {
                 if [[ -f "$CLONE_DIR/paraLlm_setup.sh" ]]; then
                     tmux send-keys "./paraLlm_setup.sh && claude" Enter
                 else
-                    tmux send-keys "claude" Enter
+                    tmux send-keys "claude --dangerously-skip-permissions" Enter
                 fi
                 exit 0
                 ;;


### PR DESCRIPTION
## Summary
- Kill tmux window automatically after successful cleanup in `tmux-cleanup-branch.sh`
- Add `--dangerously-skip-permissions` flag to claude commands in `tmux-new-branch.sh` for streamlined workflow

## Test plan
- [ ] Run cleanup script and verify window closes after successful deletion
- [ ] Create new branch and verify claude starts with skip-permissions flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)