### PR TITLE
Remove dash filter from project selection

### DIFF
--- a/tmux-new-branch.sh
+++ b/tmux-new-branch.sh
@@ -6,7 +6,7 @@ ENVS_DIR="$HOME/code/envs"
 # Ensure envs directory exists
 mkdir -p "$ENVS_DIR"
 
-# Find git repos in ~/code (base repos only - directories with .git dir, no dashes)
+# Find git repos in ~/code (base repos only - directories with .git dir at top level)
 select_repo() {
     {
         echo "← Back"
@@ -15,7 +15,6 @@ select_repo() {
             xargs -I {} dirname {} | \
             grep "^${CODE_DIR}/[^/]*$" | \
             sed "s|${CODE_DIR}/||" | \
-            grep -v '-' | \
             sort -u
     } | fzf --prompt="Select project: " --height=40% --reverse
 }


### PR DESCRIPTION
## Summary
- Removes the `grep -v '-'` filter that was excluding projects with dashes in their names from the `ctrl+b c` project selection menu

## Test plan
- [ ] Run `ctrl+b c` and verify projects with dashes in their names now appear in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)