### PR TITLE
Include all session windows in command center view

### DIFF
--- a/tmux-cc-hooks.sh
+++ b/tmux-cc-hooks.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+# Command Center Hooks - Handle dynamic window/pane changes
+# Called by tmux hooks when command center is active
+
+COMMAND_CENTER="command-center"
+ACTION="$1"
+
+# Check if command center exists
+cc_exists() {
+    tmux list-windows -F '#{window_name}' 2>/dev/null | grep -qx "$COMMAND_CENTER"
+}
+
+# Remove all command center hooks
+cleanup_hooks() {
+    tmux set-hook -gu after-new-window 2>/dev/null
+    tmux set-hook -gu pane-exited 2>/dev/null
+    tmux set-hook -gu window-unlinked 2>/dev/null
+}
+
+# Check if command center was destroyed and clean up hooks
+handle_window_unlinked() {
+    if ! cc_exists; then
+        cleanup_hooks
+    fi
+}
+
+# Handle new window creation - join it to command center
+handle_new_window() {
+    if ! cc_exists; then
+        return
+    fi
+
+    # Get the newly created window's info
+    local new_window_name new_pane_id
+    new_window_name=$(tmux display-message -p '#{window_name}')
+    new_pane_id=$(tmux display-message -p '#{pane_id}')
+
+    # Don't process if this IS the command center
+    if [[ "$new_window_name" == "$COMMAND_CENTER" ]]; then
+        return
+    fi
+
+    # Join the new pane into command center
+    tmux join-pane -s "$new_pane_id" -t "$COMMAND_CENTER" -h
+
+    # Reapply tiled layout
+    tmux select-layout -t "$COMMAND_CENTER" tiled
+
+    # Set the pane title to the window name
+    local pane_count last_pane_index
+    pane_count=$(tmux list-panes -t "$COMMAND_CENTER" 2>/dev/null | wc -l | tr -d ' ')
+    last_pane_index=$((pane_count - 1))
+    tmux select-pane -t "$COMMAND_CENTER.$last_pane_index" -T "$new_window_name"
+
+    # Switch to command center
+    tmux select-window -t "$COMMAND_CENTER"
+}
+
+# Handle pane exit - reapply layout
+handle_pane_exited() {
+    if ! cc_exists; then
+        return
+    fi
+
+    # Check if we're in the command center window
+    local current_window
+    current_window=$(tmux display-message -p '#{window_name}')
+
+    if [[ "$current_window" == "$COMMAND_CENTER" ]]; then
+        # Small delay to let tmux finish removing the pane
+        sleep 0.1
+
+        # Check if there are still panes in command center
+        local pane_count
+        pane_count=$(tmux list-panes -t "$COMMAND_CENTER" 2>/dev/null | wc -l | tr -d ' ')
+
+        if [[ "$pane_count" -gt 0 ]]; then
+            # Reapply tiled layout
+            tmux select-layout -t "$COMMAND_CENTER" tiled
+        fi
+    fi
+}
+
+case "$ACTION" in
+    new-window)
+        handle_new_window
+        ;;
+    pane-exited)
+        handle_pane_exited
+        ;;
+    window-unlinked)
+        handle_window_unlinked
+        ;;
+esac

--- a/tmux-new-branch.sh
+++ b/tmux-new-branch.sh
@@ -2,47 +2,19 @@
 
 CODE_DIR="$HOME/code"
 ENVS_DIR="$HOME/code/envs"
-COMMAND_CENTER="command-center"
 
 # Ensure envs directory exists
 mkdir -p "$ENVS_DIR"
 
-# Create a new window and add it to command center if active
+# Create a new window for a feature branch
+# The command center hooks will automatically join it if command center is active
 # Usage: create_feature_window "branch-name" "/path/to/dir"
 create_feature_window() {
     local branch_name="$1"
     local working_dir="$2"
 
-    # Check if command center window exists
-    local cc_exists
-    cc_exists=$(tmux list-windows -F '#{window_name}' 2>/dev/null | grep -x "$COMMAND_CENTER")
-
-    # Create the new window
+    # Create the new window - hooks handle command center integration automatically
     tmux new-window -n "$branch_name" -c "$working_dir"
-
-    if [[ -n "$cc_exists" ]]; then
-        # Command center is active - join this window's pane to it
-        local new_pane
-        new_pane=$(tmux display-message -p '#{pane_id}')
-
-        # Join the new pane into command center
-        tmux join-pane -s "$new_pane" -t "$COMMAND_CENTER" -h
-
-        # Reapply tiled layout
-        tmux select-layout -t "$COMMAND_CENTER" tiled
-
-        # Set the pane title
-        local pane_count
-        pane_count=$(tmux list-panes -t "$COMMAND_CENTER" | wc -l)
-        local last_pane_index=$((pane_count - 1))
-        tmux select-pane -t "$COMMAND_CENTER.$last_pane_index" -T "$branch_name"
-
-        # Select the new pane
-        tmux select-pane -t "$COMMAND_CENTER.$last_pane_index"
-
-        # Switch to command center window
-        tmux select-window -t "$COMMAND_CENTER"
-    fi
 }
 
 # Find git repos in ~/code (base repos only - directories with .git dir at top level)


### PR DESCRIPTION
## Summary
- Command center now includes **all windows** in the current tmux session, not just env-directory windows
- Adds tmux hooks for dynamic updates: new windows auto-join, layout reapplies on pane exit
- Simplifies `tmux-new-branch.sh` by delegating command center integration to hooks

## Test plan
- [ ] Open command center with `^b v` - all session windows should appear tiled
- [ ] Create a window with standard tmux (`^b n`) while command center is open - should auto-join
- [ ] Create a window with `^b c` while command center is open - should auto-join
- [ ] Exit a pane in command center - remaining panes should reflow to fill space
- [ ] Close command center - hooks should be removed (verify with `tmux show-hooks -g`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)