### PR TITLE
Add SSH and Coder remote machine support

### DIFF
--- a/.llm-context/topics/product-features.md
+++ b/.llm-context/topics/product-features.md
@@ -172,13 +172,69 @@ For regular terminals (non-Claude):
 
 ---
 
+### 8. Remote Sessions (SSH & Coder)
+Run Claude Code on remote machines via SSH or Coder workspaces while maintaining full Command Center compatibility.
+
+**Supported host types**:
+- **SSH hosts**: Any host from `~/.ssh/config` or direct hostname
+- **Coder workspaces**: Named workspaces or auto-discovery via `coder list`
+
+**Configuration** (`~/.para-llm/remote-hosts.conf`):
+```bash
+# SSH hosts
+ssh:devbox
+ssh:gpu-server
+
+# Coder workspaces (explicit)
+coder:my-workspace
+
+# Auto-discover all coder workspaces
+coder:*
+```
+
+**Workflow** (`Ctrl+b c`):
+1. Select a remote host from the "Remote" section
+2. Script tests connectivity and discovers code directory
+3. Lists git projects on the remote machine (with caching)
+4. Select project and branch
+5. Creates tmux window running: `ssh -t host "cd path && git checkout branch; claude"`
+
+**Remote session naming**:
+- Window names include hostname: `feature-xyz@devbox`
+- Command Center displays 🌐 indicator for remote sessions
+
+**Cleanup** (`Ctrl+b k`):
+- Remote sessions show in separate "Remote Sessions" section
+- Closing only kills the SSH connection
+- No files deleted on remote (safety for shared machines)
+
+**How it works**:
+- Claude Code runs **on the remote machine**
+- State detection works via terminal parsing (captures SSH output)
+- Command Center integration is seamless
+
+**Code directory discovery**:
+Checks these paths on the remote in order: `~/code`, `~/projects`, `/workspace`
+
+**Caching**:
+- Code directory: cached 10 minutes
+- Project list: cached 5 minutes
+- Cache stored in `/tmp/para-llm-remote-cache/`
+
+**Files**:
+- `remote-utils.sh` - Shared remote operation functions
+- `tmux-new-branch.sh` - Steps 4-6 for remote workflow
+
+---
+
 ## Key Bindings Summary
 
 | Binding | Action |
 |---------|--------|
-| `Ctrl+b c` | Create/resume feature environment |
-| `Ctrl+b k` | Cleanup feature environment |
+| `Ctrl+b c` | Create/resume feature environment (local or remote) |
+| `Ctrl+b k` | Cleanup feature environment or close remote session |
 | `Ctrl+b v` | Command Center (tiled view) |
+| `Ctrl+b b` | Toggle broadcast mode (type in all panes) |
 | `Ctrl+b C` | Plain new tmux window |
 
 ---

--- a/install.sh
+++ b/install.sh
@@ -18,11 +18,46 @@ chmod +x "$SCRIPT_DIR/tmux-cleanup-branch.sh"
 chmod +x "$SCRIPT_DIR/envs.sh"
 chmod +x "$SCRIPT_DIR/tmux-command-center.sh"
 chmod +x "$SCRIPT_DIR/tmux-cc-hooks.sh"
+chmod +x "$SCRIPT_DIR/remote-utils.sh"
 
 # Make plugin scripts executable (including helper scripts)
 if [[ -d "$SCRIPT_DIR/plugins/claude-state-monitor" ]]; then
     chmod +x "$SCRIPT_DIR/plugins/claude-state-monitor/"*.sh 2>/dev/null || true
     chmod +x "$SCRIPT_DIR/plugins/claude-state-monitor/hooks/"*.sh 2>/dev/null || true
+fi
+
+# Install remote utilities
+echo "Setting up remote session support..."
+
+# Create para-llm directory structure
+mkdir -p "$HOME/.para-llm"
+
+# Copy remote-utils.sh
+cp "$SCRIPT_DIR/remote-utils.sh" "$HOME/.para-llm/"
+chmod +x "$HOME/.para-llm/remote-utils.sh"
+echo "  Installed remote-utils.sh to $HOME/.para-llm/"
+
+# Create sample remote-hosts.conf if it doesn't exist
+REMOTE_HOSTS_CONFIG="$HOME/.para-llm/remote-hosts.conf"
+if [[ ! -f "$REMOTE_HOSTS_CONFIG" ]]; then
+    cat > "$REMOTE_HOSTS_CONFIG" << 'EOF'
+# Remote hosts configuration for para-llm-directory
+# Add hosts you want to connect to for remote Claude Code sessions
+#
+# Format:
+#   ssh:hostname     - SSH host (from ~/.ssh/config or hostname)
+#   coder:workspace  - Coder workspace name
+#   coder:*          - Auto-discover workspaces from `coder list`
+#
+# Examples:
+# ssh:devbox
+# ssh:gpu-server
+# coder:my-workspace
+# coder:*
+EOF
+    echo "  Created sample $REMOTE_HOSTS_CONFIG"
+else
+    echo "  $REMOTE_HOSTS_CONFIG already exists, skipping"
 fi
 
 # Install Claude Code hooks for state monitoring
@@ -126,11 +161,15 @@ echo "Scripts now at:"
 echo "  $SCRIPT_DIR"
 echo ""
 echo "Keybindings:"
-echo "  Ctrl+b c  - Create/resume feature branch"
+echo "  Ctrl+b c  - Create/resume feature branch (local or remote)"
 echo "  Ctrl+b k  - Cleanup feature branch"
 echo "  Ctrl+b v  - Command Center (tiled view of all envs)"
 echo "  Ctrl+b b  - Toggle broadcast mode (type in all panes)"
 echo "  Ctrl+b C  - Plain new window"
+echo ""
+echo "Remote Sessions:"
+echo "  Configure remote hosts in: ~/.para-llm/remote-hosts.conf"
+echo "  Then use Ctrl+b c to select a remote host and project"
 echo ""
 echo "Optional: Add this alias to your ~/.zshrc or ~/.bashrc:"
 echo "  alias envs='$SCRIPT_DIR/envs.sh'"

--- a/remote-utils.sh
+++ b/remote-utils.sh
@@ -1,0 +1,231 @@
+#!/bin/bash
+
+# Remote utilities for para-llm-directory
+# Provides functions for SSH and Coder workspace support
+
+REMOTE_HOSTS_CONFIG="$HOME/.para-llm/remote-hosts.conf"
+REMOTE_CACHE_DIR="/tmp/para-llm-remote-cache"
+
+# Ensure cache directory exists
+mkdir -p "$REMOTE_CACHE_DIR" 2>/dev/null
+
+# Parse host type from host string (ssh:hostname or coder:workspace)
+# Returns: ssh, coder, or empty if invalid
+get_host_type() {
+    local host="$1"
+    case "$host" in
+        ssh:*) echo "ssh" ;;
+        coder:*) echo "coder" ;;
+        *) echo "" ;;
+    esac
+}
+
+# Parse host name from host string (ssh:hostname -> hostname)
+get_host_name() {
+    local host="$1"
+    echo "${host#*:}"
+}
+
+# Load remote hosts from config file and optionally from coder list
+# Returns: list of hosts in format ssh:hostname or coder:workspace
+load_remote_hosts() {
+    local hosts=()
+
+    # Load from config file
+    if [[ -f "$REMOTE_HOSTS_CONFIG" ]]; then
+        while IFS= read -r line; do
+            # Skip comments and empty lines
+            [[ "$line" =~ ^#.*$ ]] && continue
+            [[ -z "${line// }" ]] && continue
+
+            # Handle coder:* wildcard
+            if [[ "$line" == "coder:*" ]]; then
+                # Auto-discover coder workspaces
+                if command -v coder &>/dev/null; then
+                    while IFS= read -r ws; do
+                        [[ -n "$ws" ]] && hosts+=("coder:$ws")
+                    done < <(coder list --output json 2>/dev/null | jq -r '.[].name' 2>/dev/null)
+                fi
+            else
+                hosts+=("$line")
+            fi
+        done < "$REMOTE_HOSTS_CONFIG"
+    fi
+
+    # Output hosts (unique)
+    printf '%s\n' "${hosts[@]}" | sort -u
+}
+
+# Test if a remote host is reachable (with timeout)
+# Returns: 0 if reachable, 1 if not
+test_remote_host() {
+    local host="$1"
+    local timeout="${2:-5}"
+    local host_type host_name
+
+    host_type=$(get_host_type "$host")
+    host_name=$(get_host_name "$host")
+
+    case "$host_type" in
+        ssh)
+            ssh -o ConnectTimeout="$timeout" -o BatchMode=yes "$host_name" "echo ok" &>/dev/null
+            return $?
+            ;;
+        coder)
+            if command -v coder &>/dev/null; then
+                coder ping "$host_name" --timeout "${timeout}s" &>/dev/null
+                return $?
+            fi
+            return 1
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Execute a command on a remote host
+# Usage: remote_exec "ssh:hostname" "command"
+remote_exec() {
+    local host="$1"
+    local cmd="$2"
+    local host_type host_name
+
+    host_type=$(get_host_type "$host")
+    host_name=$(get_host_name "$host")
+
+    case "$host_type" in
+        ssh)
+            ssh -o ConnectTimeout=10 "$host_name" "$cmd"
+            return $?
+            ;;
+        coder)
+            if command -v coder &>/dev/null; then
+                coder ssh "$host_name" -- "$cmd"
+                return $?
+            fi
+            return 1
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Discover the code directory on a remote host
+# Checks ~/code, ~/projects, /workspace in order
+# Returns: path to code directory or empty if not found
+discover_remote_code_dir() {
+    local host="$1"
+    local cache_file="$REMOTE_CACHE_DIR/code-dir-$(echo "$host" | tr ':/' '_')"
+
+    # Check cache (valid for 10 minutes)
+    if [[ -f "$cache_file" ]]; then
+        local cache_age=$(( $(date +%s) - $(stat -f %m "$cache_file" 2>/dev/null || stat -c %Y "$cache_file" 2>/dev/null || echo 0) ))
+        if [[ $cache_age -lt 600 ]]; then
+            cat "$cache_file"
+            return 0
+        fi
+    fi
+
+    # Check common code directories
+    local result
+    result=$(remote_exec "$host" '
+        for dir in ~/code ~/projects /workspace; do
+            if [[ -d "$dir" ]]; then
+                echo "$dir"
+                exit 0
+            fi
+        done
+        exit 1
+    ')
+
+    if [[ -n "$result" ]]; then
+        echo "$result" > "$cache_file"
+        echo "$result"
+        return 0
+    fi
+
+    return 1
+}
+
+# List git projects on a remote host
+# Returns: list of project names (directory names containing .git)
+list_remote_projects() {
+    local host="$1"
+    local code_dir="$2"
+    local cache_file="$REMOTE_CACHE_DIR/projects-$(echo "$host" | tr ':/' '_')"
+
+    # Check cache (valid for 5 minutes)
+    if [[ -f "$cache_file" ]]; then
+        local cache_age=$(( $(date +%s) - $(stat -f %m "$cache_file" 2>/dev/null || stat -c %Y "$cache_file" 2>/dev/null || echo 0) ))
+        if [[ $cache_age -lt 300 ]]; then
+            cat "$cache_file"
+            return 0
+        fi
+    fi
+
+    # Find git repos on remote
+    local result
+    result=$(remote_exec "$host" "
+        find '$code_dir' -maxdepth 2 -name '.git' -type d 2>/dev/null | \
+        while read gitdir; do
+            dirname \"\$gitdir\" | sed 's|^${code_dir}/||'
+        done | grep -v '/' | sort -u
+    ")
+
+    if [[ -n "$result" ]]; then
+        echo "$result" > "$cache_file"
+    fi
+
+    echo "$result"
+}
+
+# List branches for a remote project
+# Returns: list of branch names
+list_remote_branches() {
+    local host="$1"
+    local code_dir="$2"
+    local project="$3"
+
+    remote_exec "$host" "
+        cd '$code_dir/$project' 2>/dev/null || exit 1
+        git fetch --prune 2>/dev/null
+        git branch -r 2>/dev/null | grep -v 'HEAD' | sed 's|origin/||' | sed 's/^[ *]*//' | sort -u
+    "
+}
+
+# Get SSH command for a remote host
+# Returns: the ssh/coder command prefix for interactive sessions
+get_ssh_command() {
+    local host="$1"
+    local host_type host_name
+
+    host_type=$(get_host_type "$host")
+    host_name=$(get_host_name "$host")
+
+    case "$host_type" in
+        ssh)
+            echo "ssh -t $host_name"
+            ;;
+        coder)
+            echo "coder ssh $host_name --"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Clear all cached data for remote hosts
+clear_remote_cache() {
+    rm -rf "$REMOTE_CACHE_DIR"/*
+}
+
+# Get a short display name for a host
+# ssh:my-server -> my-server
+# coder:my-workspace -> my-workspace
+get_host_display_name() {
+    local host="$1"
+    get_host_name "$host"
+}


### PR DESCRIPTION
## Summary

- Add support for running Claude Code sessions on remote machines via SSH or Coder workspaces
- Remote hosts configured in `~/.para-llm/remote-hosts.conf` appear in the project selection menu
- Remote sessions maintain full Command Center compatibility (state detection works through SSH)
- Cleanup for remote sessions only closes the connection (no file deletion on remote machines)

## Changes

**New file: `remote-utils.sh`**
- Shared functions for remote operations (connectivity test, command execution, project discovery)
- Caching for code directories (10 min) and project lists (5 min)

**Modified: `tmux-new-branch.sh`**
- Added steps 4-6 for remote host selection workflow
- Added `create_remote_feature_window()` function
- Remote sessions named as `branch@hostname`

**Modified: `tmux-command-center.sh`**
- Extended state format to include host field
- Remote sessions show 🌐 indicator in pane borders

**Modified: `tmux-cleanup-branch.sh`**
- Added remote session detection and separate cleanup flow
- Remote cleanup only closes SSH connection (safety for shared machines)

**Modified: `install.sh`**
- Creates sample `~/.para-llm/remote-hosts.conf`
- Copies `remote-utils.sh` to user config directory

## Test plan

- [ ] Add SSH host to config, verify it appears in project list
- [ ] Select remote host, verify projects are discovered
- [ ] Select remote project/branch, verify Claude starts via SSH
- [ ] Open Command Center, verify remote panes show with 🌐 indicator
- [ ] Use Ctrl+b k on remote session, verify it closes cleanly
- [ ] Run mixed local and remote sessions in Command Center together

🤖 Generated with [Claude Code](https://claude.com/claude-code)