### PR TITLE
Add centralized .env file management with symlink restore on clone

### DIFF
--- a/env-manage.sh
+++ b/env-manage.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+# env-manage.sh - Interactive manager for centrally stored .env files
+# Bound to Ctrl+b e via tmux display-popup
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/para-llm-config.sh"
+
+ENV_STORE="$PARA_LLM_ROOT/.env_files"
+mkdir -p "$ENV_STORE"
+
+# Select action
+action_add() {
+    # Find .env files across all projects in CODE_DIR (skip heavy dirs)
+    local env_file
+    env_file=$(find "$CODE_DIR" \
+        \( -name node_modules -o -name .git -o -name ".para-llm-directory" \) -prune -o \
+        -name ".env*" -type f -print 2>/dev/null | \
+        sed "s|^$CODE_DIR/||" | \
+        sort | \
+        fzf --prompt="Select .env file to add: " --height=80% --reverse)
+
+    if [[ -z "$env_file" ]]; then
+        return
+    fi
+
+    local full_path="$CODE_DIR/$env_file"
+
+    # Determine the project name (first path component)
+    local project
+    project=$(echo "$env_file" | cut -d'/' -f1)
+
+    # Show detected project, allow override
+    local projects
+    projects=$(find "$CODE_DIR" -maxdepth 2 -name ".git" -type d -not -path "*/.para-llm-directory/*" 2>/dev/null | \
+        xargs -I {} dirname {} | \
+        sed "s|${CODE_DIR}/||" | \
+        grep -v '/' | \
+        sort -u)
+
+    local selected_project
+    selected_project=$(echo "$projects" | \
+        fzf --prompt="Associate with project (detected: $project): " \
+            --height=40% --reverse \
+            --query="$project")
+
+    if [[ -z "$selected_project" ]]; then
+        return
+    fi
+
+    # Compute the relative path within the project
+    local rel_path
+    rel_path=$(echo "$env_file" | sed "s|^$selected_project/||")
+
+    # Create destination directory and copy
+    local dest="$ENV_STORE/$selected_project/$rel_path"
+    mkdir -p "$(dirname "$dest")"
+    cp "$full_path" "$dest"
+    chmod 600 "$dest"
+
+    echo ""
+    echo "Added: $selected_project/$rel_path"
+    echo "Stored at: $dest"
+
+    # Auto-update existing clones for this project
+    echo ""
+    echo "Updating existing clones..."
+    for env_dir in "$ENVS_DIR"/${selected_project}-*/; do
+        if [[ -d "$env_dir" ]]; then
+            local clone_dir="${env_dir}${selected_project}"
+            if [[ -d "$clone_dir" ]]; then
+                "$SCRIPT_DIR/env-restore.sh" "$selected_project" "$clone_dir"
+                echo "  Updated: $(basename "$env_dir")"
+            fi
+        fi
+    done
+
+    echo ""
+    echo "Done. Press enter to close."
+    read -r
+}
+
+action_list() {
+    echo "=== Managed .env Files ==="
+    echo ""
+
+    local found=0
+    for project_dir in "$ENV_STORE"/*/; do
+        if [[ -d "$project_dir" ]]; then
+            local project
+            project=$(basename "$project_dir")
+            echo "[$project]"
+            while IFS= read -r -d '' file; do
+                local rel="${file#$project_dir}"
+                echo "  $rel"
+                found=1
+            done < <(find "$project_dir" -type f -print0 | sort -z)
+            echo ""
+        fi
+    done
+
+    if [[ $found -eq 0 ]]; then
+        echo "(No env files managed yet)"
+        echo ""
+        echo "Use 'Add' to register .env files from your projects."
+    fi
+
+    echo ""
+    echo "Press enter to close."
+    read -r
+}
+
+action_remove() {
+    # Collect all managed files
+    local files
+    files=$(find "$ENV_STORE" -type f 2>/dev/null | \
+        sed "s|^$ENV_STORE/||" | \
+        sort)
+
+    if [[ -z "$files" ]]; then
+        echo "No managed env files to remove."
+        echo "Press enter to close."
+        read -r
+        return
+    fi
+
+    local selected
+    selected=$(echo "$files" | \
+        fzf --prompt="Select file to remove: " --height=80% --reverse)
+
+    if [[ -z "$selected" ]]; then
+        return
+    fi
+
+    echo ""
+    echo "Remove: $selected"
+    echo -n "Are you sure? [y/N]: "
+    read -r confirm
+
+    if [[ "$confirm" =~ ^[Yy] ]]; then
+        rm -f "$ENV_STORE/$selected"
+
+        # Clean up empty parent directories
+        local dir
+        dir=$(dirname "$ENV_STORE/$selected")
+        while [[ "$dir" != "$ENV_STORE" && -d "$dir" ]]; do
+            if [[ -z "$(ls -A "$dir" 2>/dev/null)" ]]; then
+                rmdir "$dir"
+                dir=$(dirname "$dir")
+            else
+                break
+            fi
+        done
+
+        echo "Removed: $selected"
+    else
+        echo "Cancelled."
+    fi
+
+    echo ""
+    echo "Press enter to close."
+    read -r
+}
+
+# Main menu
+main() {
+    local action
+    action=$(printf "Add - register a .env file\nList - show managed files\nRemove - delete a managed file" | \
+        fzf --prompt="Env file manager: " --height=20% --reverse)
+
+    case "$action" in
+        "Add - register a .env file")
+            action_add
+            ;;
+        "List - show managed files")
+            action_list
+            ;;
+        "Remove - delete a managed file")
+            action_remove
+            ;;
+    esac
+}
+
+main

--- a/env-restore.sh
+++ b/env-restore.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# env-restore.sh - Symlink env files from central store into a clone directory
+# Usage: env-restore.sh <project-name> <clone-dir>
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/para-llm-config.sh"
+
+PROJECT_NAME="$1"
+CLONE_DIR="$2"
+
+if [[ -z "$PROJECT_NAME" || -z "$CLONE_DIR" ]]; then
+    exit 0
+fi
+
+ENV_STORE="$PARA_LLM_ROOT/.env_files/$PROJECT_NAME"
+
+# Exit silently if no env files exist for this project
+if [[ ! -d "$ENV_STORE" ]]; then
+    exit 0
+fi
+
+# Walk the store and create symlinks
+while IFS= read -r -d '' file; do
+    # Compute relative path within the store
+    rel_path="${file#$ENV_STORE/}"
+
+    target="$CLONE_DIR/$rel_path"
+
+    # Skip existing real files (not symlinks) to avoid overwriting manual placements
+    if [[ -f "$target" && ! -L "$target" ]]; then
+        continue
+    fi
+
+    # Create parent directories if needed
+    mkdir -p "$(dirname "$target")"
+
+    # Create symlink (force to update existing symlinks)
+    ln -sf "$file" "$target"
+done < <(find "$ENV_STORE" -type f -print0)

--- a/install.sh
+++ b/install.sh
@@ -61,6 +61,8 @@ mkdir -p "$PARA_LLM_ROOT/recovery"
 mkdir -p "$PARA_LLM_ROOT/scripts"
 mkdir -p "$PARA_LLM_ROOT/tmux-plugins"
 mkdir -p "$PARA_LLM_ROOT/plugins"
+mkdir -p "$PARA_LLM_ROOT/.env_files"
+chmod 700 "$PARA_LLM_ROOT/.env_files"
 
 # Write bootstrap pointer
 echo "$PARA_LLM_ROOT" > "$BOOTSTRAP_FILE"
@@ -94,6 +96,8 @@ chmod +x "$SCRIPT_DIR/envs.sh"
 chmod +x "$SCRIPT_DIR/tmux-command-center.sh"
 chmod +x "$SCRIPT_DIR/tmux-cc-hooks.sh"
 chmod +x "$SCRIPT_DIR/para-llm-config.sh"
+chmod +x "$SCRIPT_DIR/env-manage.sh"
+chmod +x "$SCRIPT_DIR/env-restore.sh"
 
 # Make plugin scripts executable (including helper scripts)
 if [[ -d "$SCRIPT_DIR/plugins/claude-state-monitor" ]]; then
@@ -228,6 +232,9 @@ bind-key v run-shell "$SCRIPT_DIR/tmux-command-center.sh"
 # Ctrl+b b: Toggle broadcast mode (type in all panes at once)
 bind-key b set-window-option synchronize-panes \; display-message "Toggled broadcast mode"
 
+# Ctrl+b e: Manage .env files (add/list/remove from central store)
+bind-key e display-popup -E -w 70% -h 70% "$SCRIPT_DIR/env-manage.sh"
+
 # para-llm-directory: session recovery
 set -g @resurrect-dir '$PARA_LLM_ROOT/recovery/resurrect'
 set -g @resurrect-capture-pane-contents 'on'
@@ -262,12 +269,14 @@ echo "    recovery/      - Session state + resurrect saves"
 echo "    scripts/       - Recovery scripts"
 echo "    tmux-plugins/  - tmux-resurrect + tmux-continuum"
 echo "    plugins/       - Claude state monitor hooks"
+echo "    .env_files/    - Centrally managed .env files (chmod 700)"
 echo ""
 echo "Keybindings:"
 echo "  Ctrl+b c  - Create/resume feature branch"
 echo "  Ctrl+b k  - Cleanup feature branch"
 echo "  Ctrl+b v  - Command Center (tiled view of all envs)"
 echo "  Ctrl+b b  - Toggle broadcast mode (type in all panes)"
+echo "  Ctrl+b e  - Manage .env files"
 echo "  Ctrl+b C  - Plain new window"
 echo "  Ctrl+b R  - Manual restore Claude sessions"
 echo ""

--- a/tmux-new-branch.sh
+++ b/tmux-new-branch.sh
@@ -230,6 +230,9 @@ main() {
                 cd "$CLONE_DIR" || exit 1
                 git checkout "$BRANCH_NAME" 2>&1
 
+                # Restore env files from central store
+                "$SCRIPT_DIR/env-restore.sh" "$REPO_NAME" "$CLONE_DIR"
+
                 create_feature_window "$BRANCH_NAME" "$CLONE_DIR"
                 # Run setup hook if it exists
                 if [[ -f "$CLONE_DIR/paraLlm_setup.sh" ]]; then
@@ -302,6 +305,9 @@ main() {
                     # Branch doesn't exist, create new branch
                     git checkout -b "$BRANCH_NAME" 2>&1
                 fi
+
+                # Restore env files from central store
+                "$SCRIPT_DIR/env-restore.sh" "$REPO_NAME" "$CLONE_DIR"
 
                 create_feature_window "$BRANCH_NAME" "$CLONE_DIR"
                 # Run setup hook if it exists


### PR DESCRIPTION
## Summary
- Adds a central `.env` file store at `$PARA_LLM_ROOT/.env_files/{project}/` that persists env files across branch clones
- `env-restore.sh` automatically symlinks stored env files into new clones (called by `tmux-new-branch.sh` after checkout)
- `env-manage.sh` provides an interactive fzf-based UI (`Ctrl+b e`) for adding, listing, and removing managed env files
- `install.sh` updated to create the store directory (chmod 700), make new scripts executable, and register the keybinding

## Test plan
- [ ] Run `install.sh` — verify `.env_files/` directory created with `chmod 700`
- [ ] `Ctrl+b e` → Add → select a `.env` file → verify copied to store with `chmod 600`
- [ ] `Ctrl+b e` → List → verify files shown grouped by project
- [ ] `Ctrl+b c` → create new branch → verify symlinks created in clone
- [ ] `Ctrl+b e` → Remove → verify file deleted and empty dirs cleaned

🤖 Generated with [Claude Code](https://claude.com/claude-code)