### PR TITLE
Bash code cleanup: portability, error handling, and security fixes

### DIFF
--- a/ctx
+++ b/ctx
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 DIR="$(dirname "$0")/.llm-context/topics"
 if [ -z "$1" ]; then
   echo "Topics:" && ls -1 "$DIR" 2>/dev/null | sed 's/\.md$//'

--- a/envs.sh
+++ b/envs.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -u
 
 # envs - Show status of all parallel development environments
 # Usage: envs [options]

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/pane-monitor.sh
+++ b/pane-monitor.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Pane Monitor - Mirrors a target tmux pane with live updates and input forwarding
 # Usage: pane-monitor.sh TARGET_PANE_ID SESSION_NAME
@@ -41,14 +41,15 @@ get_width() {
 
 # Draw header bar
 draw_header() {
-    local width=$(get_width)
+    local width
+    width="$(get_width)"
     local label=" ◆ $SESSION_NAME  [typing enabled]"
     local label_len=${#label}
     local padding=$((width - label_len))
     if [[ $padding -lt 0 ]]; then padding=0; fi
 
     # Colored header bar spanning full width
-    printf "${HEADER_BG}${HEADER_FG}${BOLD}%s%${padding}s${RESET}\n" "$label" ""
+    printf '%s%s%s%s%*s%s\n' "$HEADER_BG" "$HEADER_FG" "$BOLD" "$label" "$padding" "" "$RESET"
     # Separator line
     printf "${DIM}%*s${RESET}\n" "$width" "" | tr ' ' '─'
 }
@@ -56,7 +57,6 @@ draw_header() {
 # Track if target is still alive
 check_target_alive() {
     tmux has-session -t "$TARGET_PANE" 2>/dev/null
-    return $?
 }
 
 # Main loop with input forwarding

--- a/para-llm-config.sh
+++ b/para-llm-config.sh
@@ -1,6 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # para-llm-config.sh - Configuration loader for para-llm-directory
 # Source this file to get PARA_LLM_ROOT, CODE_DIR, and ENVS_DIR variables
+
+set -u
 
 BOOTSTRAP_FILE="$HOME/.para-llm-root"
 

--- a/plugins/claude-state-monitor/get-pane-display.sh
+++ b/plugins/claude-state-monitor/get-pane-display.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -u
 
 # Get display string for a pane by index
 # Called by tmux pane-border-format: #(/path/to/get-pane-display.sh #{pane_index})

--- a/plugins/claude-state-monitor/monitor-manager.sh
+++ b/plugins/claude-state-monitor/monitor-manager.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Claude State Monitor Manager
 # Manages state-detector processes for Command Center panes

--- a/plugins/claude-state-monitor/state-detector.sh
+++ b/plugins/claude-state-monitor/state-detector.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Pane State Detector - Simple terminal-based state detection
 # Detects whether a pane is waiting for input or actively working

--- a/scripts/para-llm-do-discard.sh
+++ b/scripts/para-llm-do-discard.sh
@@ -1,6 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # para-llm-do-discard.sh - Discard recovery state
 # Called from recovery prompt menu
+
+set -u
 
 BOOTSTRAP_FILE="$HOME/.para-llm-root"
 if [[ ! -f "$BOOTSTRAP_FILE" ]]; then

--- a/scripts/para-llm-do-restore.sh
+++ b/scripts/para-llm-do-restore.sh
@@ -1,6 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # para-llm-do-restore.sh - Execute the restore action
 # Called from recovery prompt menu
+
+set -u
 
 BOOTSTRAP_FILE="$HOME/.para-llm-root"
 if [[ ! -f "$BOOTSTRAP_FILE" ]]; then

--- a/scripts/para-llm-recovery-prompt.sh
+++ b/scripts/para-llm-recovery-prompt.sh
@@ -1,6 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # para-llm-recovery-prompt.sh - Prompt user to restore saved sessions on tmux start
 # Runs via session-created hook
+
+set -u
 
 # Read PARA_LLM_ROOT from bootstrap pointer
 BOOTSTRAP_FILE="$HOME/.para-llm-root"

--- a/scripts/para-llm-restore.sh
+++ b/scripts/para-llm-restore.sh
@@ -1,6 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # para-llm-restore.sh - Re-launch Claude in restored panes
 # Idempotent: checks that pane is idle before launching
+
+set -u
 
 # Read PARA_LLM_ROOT from bootstrap pointer
 BOOTSTRAP_FILE="$HOME/.para-llm-root"

--- a/scripts/para-llm-save-state.sh
+++ b/scripts/para-llm-save-state.sh
@@ -1,6 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # para-llm-save-state.sh - Save Claude session state for recovery
 # Called by tmux-resurrect's @resurrect-hook-post-save-all (every 1 minute via continuum)
+
+set -u
 
 # Read PARA_LLM_ROOT from bootstrap pointer
 BOOTSTRAP_FILE="$HOME/.para-llm-root"
@@ -39,7 +41,7 @@ SESSION_NAME=$(echo "$PANE_DATA" | head -1 | cut -d'|' -f1)
         if [[ "$pane_path" == "$ENVS_DIR"/* ]]; then
             # Derive project and branch from path
             # Path structure: $ENVS_DIR/<project>-<branch>/<project>/...
-            REL_PATH="${pane_path#$ENVS_DIR/}"
+            REL_PATH="${pane_path#"$ENVS_DIR"/}"
             ENV_NAME="${REL_PATH%%/*}"
 
             # Extract project and branch from env name (format: project-branch)
@@ -66,7 +68,7 @@ SESSION_NAME=$(echo "$PANE_DATA" | head -1 | cut -d'|' -f1)
 
                 if [[ -n "$PROJECT" ]]; then
                     # Branch is env_name with project prefix removed
-                    BRANCH="${ENV_NAME#$PROJECT-}"
+                    BRANCH="${ENV_NAME#"$PROJECT"-}"
 
                     # Check if Claude is running in this pane
                     HAD_CLAUDE="false"

--- a/tmux-cc-hooks.sh
+++ b/tmux-cc-hooks.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -u
 
 # Command Center Hooks - Handle dynamic window/pane changes
 # Called by tmux hooks when command center is active

--- a/tmux-cleanup-branch.sh
+++ b/tmux-cleanup-branch.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -127,7 +129,7 @@ main() {
                 # Check for unpushed changes
                 CLONE_DIR=$(find "$ENV_DIR" -maxdepth 1 -type d ! -name "$(basename "$ENV_DIR")" | head -1)
                 if [[ -d "$CLONE_DIR/.git" ]]; then
-                    cd "$CLONE_DIR"
+                    cd "$CLONE_DIR" || exit 1
                     UNPUSHED=$(git log --oneline @{u}.. 2>/dev/null | wc -l | tr -d ' ')
                     if [[ "$UNPUSHED" -gt 0 ]]; then
                         echo "WARNING: $UNPUSHED unpushed commit(s) detected!"
@@ -188,9 +190,7 @@ main() {
 
                 # Delete the environment
                 echo "Deleting $ENV_DIR..."
-                rm -rf "$ENV_DIR"
-
-                if [[ $? -eq 0 ]]; then
+                if rm -rf "$ENV_DIR"; then
                     echo "✓ Deleted successfully"
                 else
                     echo "Failed to delete"

--- a/tmux-command-center.sh
+++ b/tmux-command-center.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -u
 
 # Command Center - Tiled view of all windows in the current session
 # Moves actual panes into a tiled layout for direct interaction
@@ -155,7 +157,7 @@ create_command_center() {
     empty_pane=$(tmux display-message -t "$COMMAND_CENTER" -p '#{pane_id}')
 
     # Save state: which panes we're borrowing and from where
-    > "$STATE_FILE"
+    : > "$STATE_FILE"
 
     # Join ALL panes into command center (this kills their original windows)
     for entry in "${windows[@]}"; do
@@ -217,21 +219,15 @@ start_state_monitor() {
 }
 
 # Main: Smart command center toggle
-# Debug: log state to temp file
-echo "$(date): exists=$(command_center_exists && echo Y || echo N) in_cc=$(in_command_center && echo Y || echo N) current=$(tmux display-message -p '#{window_name}')" >> /tmp/cc-debug.log
-
 if command_center_exists; then
     if in_command_center; then
         # In command center: close it and restore panes
-        echo "$(date): -> restore_command_center" >> /tmp/cc-debug.log
         restore_command_center
     else
         # Not in command center but it exists: switch to it
-        echo "$(date): -> goto_command_center" >> /tmp/cc-debug.log
         goto_command_center
     fi
 else
     # No command center: create it
-    echo "$(date): -> create_command_center" >> /tmp/cc-debug.log
     create_command_center
 fi


### PR DESCRIPTION
## Summary
- Updates all 18 scripts to use portable `#!/usr/bin/env bash` shebang and adds `set -u` for unset variable detection where appropriate
- Fixes security issues: JSON injection via heredoc (now uses `jq`), unsafe `source` of `/tmp` file (now uses `grep/cut`)
- Removes dead code (debug logging to `/tmp`), fixes error handling anti-patterns (`$?` checks → `if !` / `if cmd`), and resolves shellcheck warnings (printf format injection, unquoted substitutions, missing `read -r`)

## Test plan
- [ ] Run `shellcheck` on all 18 modified scripts — remaining warnings should only be informational (SC1083 git refspec, SC2034 intentional unused vars, SC1090 dynamic source)
- [ ] Verify `install.sh` completes successfully
- [ ] Verify `tmux-new-branch.sh` clone flow works (new branch + attach to existing remote branch)
- [ ] Verify `tmux-command-center.sh` toggle (create/switch/restore)
- [ ] Verify `tmux-cleanup-branch.sh` delete flow with unpushed commit warning
- [ ] Verify state-tracker.sh produces valid JSON output via hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)