### PR TITLE
Add multi-repo support for feature environments

### DIFF
--- a/plugins/claude-state-monitor/hooks/state-tracker.sh
+++ b/plugins/claude-state-monitor/hooks/state-tracker.sh
@@ -131,7 +131,7 @@ if [[ -n "$CWD" ]]; then
         fi
 
         # Write display file for pane-border-format
-        DISPLAY_STRING="$LABEL | $PROJECT | $BRANCH"
+        DISPLAY_STRING="$LABEL | $BRANCH | $PROJECT"
         SAFE_PANE_ID="${PANE_ID//\%/}"
         mkdir -p "$DISPLAY_DIR"
         echo "$DISPLAY_STRING" > "$DISPLAY_DIR/$SAFE_PANE_ID"

--- a/plugins/claude-state-monitor/state-detector.sh
+++ b/plugins/claude-state-monitor/state-detector.sh
@@ -165,7 +165,7 @@ write_display() {
         *)       label="$LABEL_WORKING" ;;
     esac
 
-    local display="$label | $PROJECT | $BRANCH"
+    local display="$label | $BRANCH | $PROJECT"
     local safe_id="${PANE_ID//\%/}"
     echo "$display" > "$DISPLAY_DIR/$safe_id"
 }


### PR DESCRIPTION
## Summary

- Enable selecting multiple repositories when creating a new feature environment using Tab key for multi-select
- Prompt for a project name when multiple repos are selected (e.g., "shoebox")
- Clone all selected repos into a single environment directory
- Auto-generate CLAUDE.md with multi-repo best practices (commit messages, PR linking, merge coordination)
- Window naming uses format: `project multi-repo (N)` where N is repo count
- Update cleanup script to check all repos for unpushed commits
- Update cleanup to find panes by working directory as fallback
- Fix display format order to show window name first

## Test plan

- [ ] Single repo selection still works as before
- [ ] Multi-select with Tab selects multiple repos
- [ ] Project name prompt appears for multi-repo
- [ ] All repos cloned to same env directory
- [ ] CLAUDE.md generated in env root for multi-repo
- [ ] Window name shows "project multi-repo (N)" format
- [ ] Cleanup detects unpushed commits in all repos
- [ ] Cleanup removes pane from command center

🤖 Generated with [Claude Code](https://claude.com/claude-code)