### PR TITLE
Fix window titles missing after tmux resume

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -73,6 +73,9 @@ cat > "$PARA_LLM_ROOT/config" << EOF
 
 # Directory containing your base git repositories
 CODE_DIR="$CODE_DIR"
+
+# Directory where para-llm-directory is installed (plugin scripts live here)
+INSTALL_DIR="$SCRIPT_DIR"
 EOF
 
 echo "Configuration saved:"

--- a/scripts/para-llm-restore.sh
+++ b/scripts/para-llm-restore.sh
@@ -14,7 +14,14 @@ PARA_LLM_ROOT="$(cat "$BOOTSTRAP_FILE")"
 ENVS_DIR="$PARA_LLM_ROOT/envs"
 
 STATE_FILE="$PARA_LLM_ROOT/recovery/session-state"
+DISPLAY_DIR="$PARA_LLM_ROOT/recovery/pane-display"
 LOG_FILE="$PARA_LLM_ROOT/recovery/restore.log"
+
+# Read INSTALL_DIR from config (needed to find plugin scripts)
+INSTALL_DIR=""
+if [[ -f "$PARA_LLM_ROOT/config" ]]; then
+    source "$PARA_LLM_ROOT/config"
+fi
 
 if [[ ! -f "$STATE_FILE" ]]; then
     tmux display-message "para-llm: No recovery state found"
@@ -43,6 +50,32 @@ if [[ ${#SAVED_ENTRIES[@]} -eq 0 ]]; then
     exit 0
 fi
 
+# Check if command-center window exists and re-apply its window options
+COMMAND_CENTER="command-center"
+HAS_COMMAND_CENTER=false
+if tmux list-windows -F '#{window_name}' 2>/dev/null | grep -qxF "$COMMAND_CENTER"; then
+    HAS_COMMAND_CENTER=true
+
+    if [[ -n "$INSTALL_DIR" ]]; then
+        # Re-apply pane border settings (tmux-resurrect doesn't restore window options)
+        local_display_helper="$INSTALL_DIR/plugins/claude-state-monitor/get-pane-display.sh"
+        if [[ -f "$local_display_helper" ]]; then
+            tmux set-window-option -t "$COMMAND_CENTER" pane-border-status top
+            tmux set-window-option -t "$COMMAND_CENTER" pane-border-format \
+                "#{?pane_active,** , }#{pane_index}: #($local_display_helper #{pane_index})#{?pane_active, **,} "
+            echo "  Re-applied command-center window options" >> "$LOG_FILE"
+        else
+            echo "  WARN: display helper not found at $local_display_helper" >> "$LOG_FILE"
+        fi
+    else
+        echo "  WARN: INSTALL_DIR not set in config, cannot restore command-center display" >> "$LOG_FILE"
+    fi
+fi
+
+# Ensure display and mapping directories exist
+mkdir -p "$DISPLAY_DIR"
+mkdir -p "/tmp/claude-pane-mapping/by-cwd"
+
 # Get current pane information
 RESTORED=0
 SKIPPED=0
@@ -66,6 +99,18 @@ while IFS='|' read -r pane_id pane_path pane_pid; do
             continue
         fi
 
+        # Create display file for this pane's new ID
+        safe_pane_id="${pane_id//\%/}"
+        echo "Starting... | $branch | $project" > "$DISPLAY_DIR/$safe_pane_id"
+
+        # Create pane mapping so state-tracker hooks can find this pane
+        cwd_safe=$(echo "$pane_path" | sed 's|/|_|g' | sed 's|^_||')
+        cat > "/tmp/claude-pane-mapping/by-cwd/$cwd_safe" << MAPPING_EOF
+PANE_ID=$pane_id
+PROJECT=$project
+BRANCH=$branch
+MAPPING_EOF
+
         # Determine launch command
         SETUP_SCRIPT="$pane_path/paraLlm_setup.sh"
         if [[ -f "$SETUP_SCRIPT" ]]; then
@@ -76,7 +121,7 @@ while IFS='|' read -r pane_id pane_path pane_pid; do
 
         # Send command to the pane
         tmux send-keys -t "$pane_id" "$LAUNCH_CMD" Enter
-        echo "  RESTORED $project/$branch in $pane_id" >> "$LOG_FILE"
+        echo "  RESTORED $project/$branch in $pane_id (display: $safe_pane_id)" >> "$LOG_FILE"
         RESTORED=$((RESTORED + 1))
 
         # Brief pause between launches to avoid overwhelming
@@ -85,4 +130,20 @@ while IFS='|' read -r pane_id pane_path pane_pid; do
 done < <(tmux list-panes -a -F '#{pane_id}|#{pane_current_path}|#{pane_pid}' 2>/dev/null)
 
 echo "  Summary: restored=$RESTORED skipped=$SKIPPED" >> "$LOG_FILE"
+
+# Start state monitor if command-center exists and we restored panes
+if [[ "$HAS_COMMAND_CENTER" == true ]] && [[ $RESTORED -gt 0 ]] && [[ -n "$INSTALL_DIR" ]]; then
+    MONITOR_PLUGIN="$INSTALL_DIR/plugins/claude-state-monitor/monitor-manager.sh"
+    if [[ -x "$MONITOR_PLUGIN" ]]; then
+        nohup "$MONITOR_PLUGIN" attach "$COMMAND_CENTER" </dev/null >/dev/null 2>&1 &
+        echo "  Started state monitor (PID: $!)" >> "$LOG_FILE"
+    elif [[ -f "$MONITOR_PLUGIN" ]]; then
+        chmod +x "$MONITOR_PLUGIN" 2>/dev/null
+        nohup "$MONITOR_PLUGIN" attach "$COMMAND_CENTER" </dev/null >/dev/null 2>&1 &
+        echo "  Started state monitor (PID: $!)" >> "$LOG_FILE"
+    else
+        echo "  WARN: monitor-manager.sh not found at $MONITOR_PLUGIN" >> "$LOG_FILE"
+    fi
+fi
+
 tmux display-message "para-llm: Restored $RESTORED Claude session(s), skipped $SKIPPED"


### PR DESCRIPTION
## Summary
- **Store `INSTALL_DIR` in config** so restore scripts can find plugin scripts (display helper, monitor manager)
- **Re-apply command-center window options** (`pane-border-status`, `pane-border-format`) after tmux-resurrect restore, since resurrect doesn't preserve window-level options
- **Create display files for new pane IDs** with initial "Starting... | branch | project" content, and set up pane mappings for hooks-based state tracking
- **Restart the state monitor** after restore so title bars update to "Working" / "Waiting for Input" once Claude starts

## Test plan
- [ ] Re-run `install.sh` to write updated config with `INSTALL_DIR`
- [ ] Open command center (`Ctrl+b v`) with env windows, verify title bars show project/branch info
- [ ] Kill tmux server (`tmux kill-server`)
- [ ] Start tmux, choose "Restore" at recovery prompt
- [ ] Verify command-center window has title bars showing "Starting... | branch | project"
- [ ] Verify titles update to "Working" / "Waiting for Input" once Claude starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)