### PR TITLE
Improve CLI input: mouse support and iTerm2 recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Tmux workflow for managing parallel Claude Code sessions across multiple feature
 
 - **Shift+Enter**: Insert newline in Claude Code REPL (requires iTerm2 with CSI u — see below)
 - **Mouse/trackpad**: Scroll tmux panes and click to select panes
+- **Option+drag**: Select and copy text (Cmd+C to copy, iTerm2 native selection)
 
 ## Recommended Terminal
 

--- a/install.sh
+++ b/install.sh
@@ -222,6 +222,8 @@ set -as terminal-features 'xterm*:extkeys'
 # Enable mouse/trackpad scrolling and pane selection
 set -g mouse on
 
+# Copy text: Option+drag to select, then Cmd+C to copy (iTerm2 native selection)
+
 # Ctrl+b c: interactive project + branch selection, creates clone in envs/
 bind-key c display-popup -E -w 60% -h 60% "$SCRIPT_DIR/tmux-new-branch.sh"
 


### PR DESCRIPTION
## Summary
- Enable tmux mouse mode (`set -g mouse on`) for trackpad scrolling in copy mode and click-to-select panes in command center view
- Add "Recommended Terminal" section to README documenting that iTerm2 with CSI u is required for Shift+Enter newlines (macOS Terminal.app sends identical bytes for Enter and Shift+Enter)
- Configure tmux extended keys for Shift+Enter passthrough

## Test plan
- [ ] Run `install.sh` and verify `set -g mouse on` is added to `~/.tmux.conf`
- [ ] Verify trackpad scrolling works in tmux copy mode (`Ctrl+b [`)
- [ ] Verify click-to-select panes works in command center view
- [ ] Verify Shift+Enter works in Claude Code REPL with iTerm2 + CSI u enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)