### PR TITLE
Fix multi-repo resume flow and command center parsing

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,14 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BOOTSTRAP_FILE="$HOME/.para-llm-root"
 
+# Parse flags
+NON_INTERACTIVE=false
+for arg in "$@"; do
+    case "$arg" in
+        -y|--yes) NON_INTERACTIVE=true ;;
+    esac
+done
+
 echo "Installing para-llm-directory..."
 echo ""
 
@@ -18,9 +26,13 @@ if [[ -f "$BOOTSTRAP_FILE" ]]; then
         echo "  Base repos directory: $CODE_DIR"
         echo "  Para-LLM root: $PARA_LLM_ROOT"
         echo ""
-        read -r -p "Keep existing settings? [Y/n]: " KEEP_CONFIG
-        if [[ "$KEEP_CONFIG" =~ ^[Nn] ]]; then
-            unset CODE_DIR PARA_LLM_ROOT
+        if [[ "$NON_INTERACTIVE" == true ]]; then
+            echo "Keeping existing settings (-y)"
+        else
+            read -r -p "Keep existing settings? [Y/n]: " KEEP_CONFIG
+            if [[ "$KEEP_CONFIG" =~ ^[Nn] ]]; then
+                unset CODE_DIR PARA_LLM_ROOT
+            fi
         fi
         echo ""
     fi
@@ -28,26 +40,36 @@ fi
 
 # Prompt for directories if not already set
 if [[ -z "$CODE_DIR" ]]; then
-    echo "Where are your base git repositories located?"
-    echo "(This is where you keep your main project checkouts)"
-    echo ""
     DEFAULT_CODE_DIR="$HOME/code"
-    read -r -p "Base repos directory [$DEFAULT_CODE_DIR]: " CODE_DIR
-    CODE_DIR="${CODE_DIR:-$DEFAULT_CODE_DIR}"
-    # Expand ~ to $HOME
-    CODE_DIR="${CODE_DIR/#\~/$HOME}"
+    if [[ "$NON_INTERACTIVE" == true ]]; then
+        CODE_DIR="$DEFAULT_CODE_DIR"
+        echo "Using default base repos directory: $CODE_DIR"
+    else
+        echo "Where are your base git repositories located?"
+        echo "(This is where you keep your main project checkouts)"
+        echo ""
+        read -r -p "Base repos directory [$DEFAULT_CODE_DIR]: " CODE_DIR
+        CODE_DIR="${CODE_DIR:-$DEFAULT_CODE_DIR}"
+        # Expand ~ to $HOME
+        CODE_DIR="${CODE_DIR/#\~/$HOME}"
+    fi
     echo ""
 fi
 
 if [[ -z "$PARA_LLM_ROOT" ]]; then
-    echo "Where should para-llm-directory store its data?"
-    echo "(Environments, recovery state, and plugins live here)"
-    echo ""
     DEFAULT_PARA_LLM_ROOT="$CODE_DIR/.para-llm-directory"
-    read -r -p "Para-LLM root [$DEFAULT_PARA_LLM_ROOT]: " PARA_LLM_ROOT
-    PARA_LLM_ROOT="${PARA_LLM_ROOT:-$DEFAULT_PARA_LLM_ROOT}"
-    # Expand ~ to $HOME
-    PARA_LLM_ROOT="${PARA_LLM_ROOT/#\~/$HOME}"
+    if [[ "$NON_INTERACTIVE" == true ]]; then
+        PARA_LLM_ROOT="$DEFAULT_PARA_LLM_ROOT"
+        echo "Using default para-llm root: $PARA_LLM_ROOT"
+    else
+        echo "Where should para-llm-directory store its data?"
+        echo "(Environments, recovery state, and plugins live here)"
+        echo ""
+        read -r -p "Para-LLM root [$DEFAULT_PARA_LLM_ROOT]: " PARA_LLM_ROOT
+        PARA_LLM_ROOT="${PARA_LLM_ROOT:-$DEFAULT_PARA_LLM_ROOT}"
+        # Expand ~ to $HOME
+        PARA_LLM_ROOT="${PARA_LLM_ROOT/#\~/$HOME}"
+    fi
     echo ""
 fi
 

--- a/tmux-command-center.sh
+++ b/tmux-command-center.sh
@@ -128,9 +128,9 @@ discover_windows() {
     local current_session
     current_session=$(tmux display-message -p '#{session_name}')
 
-    # List all windows in current session: session:index window_name pane_id pane_current_path
-    tmux list-windows -t "$current_session" -F '#{session_name}:#{window_index} #{window_name} #{pane_id} #{pane_current_path}' 2>/dev/null | \
-    while read -r session_window window_name pane_id pane_path; do
+    # List all windows in current session (pipe-delimited to handle spaces in names)
+    tmux list-windows -t "$current_session" -F '#{session_name}:#{window_index}|#{window_name}|#{pane_id}|#{pane_current_path}' 2>/dev/null | \
+    while IFS='|' read -r session_window window_name pane_id pane_path; do
         # Don't include command center itself
         if [[ "$window_name" != "$COMMAND_CENTER" ]]; then
             # Extract project name from path (last directory component)


### PR DESCRIPTION
## Summary
- **Multi-repo flow**: After selecting repos, immediately prompt Resume/New/Attach instead of asking for a project name first. When choosing "New", only ask for a project name which is also used as the git branch name — no redundant second prompt.
- **Command center**: Fix `discover_windows` parsing so window names with spaces (e.g. `"my-project multi-repo (2)"`) don't break pane discovery. Switches from space-delimited to pipe-delimited tmux output.
- **Install**: Add `-y`/`--yes` flag for non-interactive installs that accept existing config and defaults.

## Test plan
- [x] Select multiple repos with `Ctrl+b c` → verify Resume/New/Attach appears immediately (no project name prompt)
- [x] Choose "New" → verify only one "Project name" prompt, and it's used as the git branch in all repos
- [x] Choose "Resume" → verify it finds existing multi-repo environments by scanning for matching repo subdirs
- [x] Open 2+ windows then `Ctrl+b v` → verify all windows appear in command center (especially with spaces in names)
- [x] `Ctrl+b v` again from command center → verify it restores all windows
- [x] Run `install.sh -y` → verify no interactive prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)