### PR TITLE
Open command center after restore resumes Claude sessions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -95,6 +95,9 @@ cat > "$PARA_LLM_ROOT/config" << EOF
 
 # Directory containing your base git repositories
 CODE_DIR="$CODE_DIR"
+
+# Directory where para-llm-directory is installed (source scripts)
+INSTALL_DIR="$SCRIPT_DIR"
 EOF
 
 echo "Configuration saved:"

--- a/scripts/para-llm-do-restore.sh
+++ b/scripts/para-llm-do-restore.sh
@@ -10,6 +10,11 @@ if [[ ! -f "$BOOTSTRAP_FILE" ]]; then
 fi
 PARA_LLM_ROOT="$(cat "$BOOTSTRAP_FILE")"
 
+# Load config for INSTALL_DIR
+if [[ -f "$PARA_LLM_ROOT/config" ]]; then
+    source "$PARA_LLM_ROOT/config"
+fi
+
 RESURRECT_DIR="$PARA_LLM_ROOT/tmux-plugins/tmux-resurrect"
 
 # Run tmux-resurrect restore
@@ -24,3 +29,10 @@ sleep 2
 # Re-launch Claude sessions
 tmux display-message "para-llm: Re-launching Claude sessions..."
 "$PARA_LLM_ROOT/scripts/para-llm-restore.sh"
+
+# Open command center view after Claude sessions are launched
+COMMAND_CENTER_SCRIPT="${INSTALL_DIR:-}/tmux-command-center.sh"
+if [[ -n "${INSTALL_DIR:-}" && -x "$COMMAND_CENTER_SCRIPT" ]]; then
+    sleep 1
+    tmux run-shell -b "$COMMAND_CENTER_SCRIPT"
+fi


### PR DESCRIPTION
## Summary
- After restoring tmux layout and launching `claude --dangerously-skip-permissions --resume` in each pane, automatically opens the command center tiled view (equivalent to `Ctrl+b v`)
- Persists `INSTALL_DIR` in the config file so restore scripts can locate `tmux-command-center.sh`
- Gracefully degrades if `INSTALL_DIR` is missing from config (pre-existing installs that haven't re-run install)

## Test plan
- [ ] Run `install.sh` and verify `INSTALL_DIR` is written to `$PARA_LLM_ROOT/config`
- [ ] Kill tmux, restart, select "Restore" from recovery prompt
- [ ] Verify windows restore to correct directories, Claude resumes in each pane, and command center view opens automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)