### PR TITLE
Fix pane display using colored format consistently

### DIFF
--- a/plugins/claude-state-monitor/state-detector.sh
+++ b/plugins/claude-state-monitor/state-detector.sh
@@ -157,15 +157,15 @@ update_border_style() {
 # Write display string for pane-border-format
 write_display() {
     local state="$1"
-    local label
+    local color
 
     case "$state" in
-        ready)   label="$LABEL_READY" ;;
-        working) label="$LABEL_WORKING" ;;
-        *)       label="$LABEL_WORKING" ;;
+        ready)   color="$COLOR_READY" ;;
+        working) color="$COLOR_WORKING" ;;
+        *)       color="$COLOR_WORKING" ;;
     esac
 
-    local display="$label | $BRANCH | $PROJECT"
+    local display="#[fg=$color]$PROJECT | $BRANCH#[default]"
     local safe_id="${PANE_ID//\%/}"
     echo "$display" > "$DISPLAY_DIR/$safe_id"
 }

--- a/tmux-command-center.sh
+++ b/tmux-command-center.sh
@@ -217,7 +217,7 @@ create_command_center() {
     mkdir -p "$PANE_DISPLAY_DIR"
     while IFS='|' read -r pane_id name origin project; do
         local safe_id="${pane_id//\%/}"
-        echo "${project} | ${name}" > "$PANE_DISPLAY_DIR/$safe_id"
+        echo "#[fg=green]${project} | ${name}#[default]" > "$PANE_DISPLAY_DIR/$safe_id"
     done < "$STATE_FILE"
 
     # Select first pane


### PR DESCRIPTION
## Summary
- **state-detector.sh** was overwriting the colored display files (written by state-tracker.sh) with the old uncolored `"$label | $BRANCH | $PROJECT"` format every 0.3s
- Updated `write_display()` in state-detector.sh to use `#[fg=$color]$PROJECT | $BRANCH#[default]` matching state-tracker.sh
- Updated tmux-command-center.sh initial display file write to use the same colored format

## Test plan
- [ ] Open command center (`Ctrl+b v`) and verify pane border titles show colored project/branch text
- [ ] Run Claude in a pane and verify the border title stays colored as state-detector polls
- [ ] Verify state-tracker.sh hook updates are no longer overwritten by state-detector

🤖 Generated with [Claude Code](https://claude.com/claude-code)