### PR TITLE
Add status label back to colored pane display format

### DIFF
--- a/plugins/claude-state-monitor/hooks/state-tracker.sh
+++ b/plugins/claude-state-monitor/hooks/state-tracker.sh
@@ -150,7 +150,7 @@ MAPEOF
         fi
 
         # Write display file for pane-border-format (with color codes)
-        DISPLAY_STRING="#[fg=$COLOR]$PROJECT | $BRANCH#[default]"
+        DISPLAY_STRING="#[fg=$COLOR]$LABEL | $PROJECT | $BRANCH#[default]"
         SAFE_PANE_ID="${PANE_ID//\%/}"
         mkdir -p "$DISPLAY_DIR"
         echo "$DISPLAY_STRING" > "$DISPLAY_DIR/$SAFE_PANE_ID"

--- a/plugins/claude-state-monitor/state-detector.sh
+++ b/plugins/claude-state-monitor/state-detector.sh
@@ -165,7 +165,14 @@ write_display() {
         *)       color="$COLOR_WORKING" ;;
     esac
 
-    local display="#[fg=$color]$PROJECT | $BRANCH#[default]"
+    local label
+    case "$state" in
+        ready)   label="$LABEL_READY" ;;
+        working) label="$LABEL_WORKING" ;;
+        *)       label="$LABEL_WORKING" ;;
+    esac
+
+    local display="#[fg=$color]$label | $PROJECT | $BRANCH#[default]"
     local safe_id="${PANE_ID//\%/}"
     echo "$display" > "$DISPLAY_DIR/$safe_id"
 }

--- a/tmux-command-center.sh
+++ b/tmux-command-center.sh
@@ -217,7 +217,7 @@ create_command_center() {
     mkdir -p "$PANE_DISPLAY_DIR"
     while IFS='|' read -r pane_id name origin project; do
         local safe_id="${pane_id//\%/}"
-        echo "#[fg=green]${project} | ${name}#[default]" > "$PANE_DISPLAY_DIR/$safe_id"
+        echo "#[fg=green]Waiting for Input | ${project} | ${name}#[default]" > "$PANE_DISPLAY_DIR/$safe_id"
     done < "$STATE_FILE"
 
     # Select first pane


### PR DESCRIPTION
## Summary
- The colored format from #34 dropped the state label, showing only `project | branch`
- Restored to `label | project | branch` with color indicating state (green=ready, yellow=working, cyan=blocked)
- Updated all three display writers: `state-detector.sh`, `state-tracker.sh`, `tmux-command-center.sh`

## Test plan
- [ ] Verify pane titles show e.g. `Waiting for Input | paraLlmDirectory | main` in green
- [ ] Run Claude and verify title changes to `Working | paraLlmDirectory | main` in yellow
- [ ] Check command center initial titles include the label

🤖 Generated with [Claude Code](https://claude.com/claude-code)