### PR TITLE
Standardize pane border title format

### DIFF
--- a/.llm-context/topics/architectural-decisions.md
+++ b/.llm-context/topics/architectural-decisions.md
@@ -194,18 +194,24 @@ Hooks are configured in `~/.claude/settings.json`:
 ```
 
 **State Mapping**:
-| Hook Event | State | Display |
-|------------|-------|---------|
-| `PreToolUse` | working | `Working: <tool_name>` |
-| `PostToolUse` | working | `Working` |
-| `Stop` | ready | `Waiting for Input` |
-| `Notification (idle_prompt)` | ready | `Waiting for Input` |
-| `Notification (permission_prompt)` | blocked | `Needs Action: Permission` |
+| Hook Event | State | Display | Color |
+|------------|-------|---------|-------|
+| `PreToolUse` | working | `Working: <tool_name>` | Yellow |
+| `PostToolUse` | working | `Working` | Yellow |
+| `Stop` | ready | `Waiting for Input` | Green |
+| `Notification (idle_prompt)` | ready | `Waiting for Input` | Green |
+| `Notification (permission_prompt)` | blocked | `Needs Action: Permission` | Cyan |
 
-**For Non-Claude Terminals**:
+**For Non-Claude Terminals** (state-detector.sh):
 - Checks if shell has child processes
-- Child processes running → `Working`
-- No children (idle shell) → `Waiting for Input`
+- Child processes running → `Working` (yellow)
+- No children (idle shell) → `Waiting for Input` (green)
+
+**For Unmanaged Panes** (get-pane-display.sh fallback):
+| Scenario | Display | Color |
+|----------|---------|-------|
+| Not a git repo | `No Git \| <dirname>` | Default |
+| Git repo, no Claude | `No Claude \| <dirname> \| <branch>` | Green |
 
 **Rationale**:
 - **Accurate**: Uses official Claude Code events, not terminal parsing

--- a/.llm-context/topics/product-features.md
+++ b/.llm-context/topics/product-features.md
@@ -119,12 +119,19 @@ Visual feedback showing whether each Command Center tile is waiting for input or
 
 **Tile Title Bar Format**:
 ```
-pane_index: status | project | branch
+pane_index: status | directory | branch
 ```
+
+Display files contain: `#[fg=<color>]<status> | <directory> | <branch>#[default]`
+
+For non-git panes: `#[fg=default]No Git | <directory>#[default]` (no branch field)
 
 Example titles:
 - `0: Waiting for Input | myProject | feature-auth`
-- `1: Working | myProject | bugfix-login`
+- `1: Working: Bash | myProject | bugfix-login`
+- `2: Needs Action: Permission | myProject | feature-auth`
+- `3: No Claude | myProject | main`
+- `4: No Git | scripts`
 
 **Active Pane Indicator**:
 The currently selected pane is marked with asterisks (handled by tmux `pane-border-format`):
@@ -132,11 +139,14 @@ The currently selected pane is marked with asterisks (handled by tmux `pane-bord
 ** 0: Waiting for Input | myProject | feature-auth **
 ```
 
-**Two States**:
+**States**:
 | State | Color | Meaning |
 |-------|-------|---------|
-| **Waiting for Input** | Green | Prompt visible, ready for user input |
-| **Working** | Yellow | Command running or Claude processing |
+| **Waiting for Input** | Green | Claude prompt visible, ready for user input |
+| **Working** / **Working: \<tool\>** | Yellow | Claude actively processing or tool running |
+| **Needs Action: Permission** | Cyan | Claude needs permission approval |
+| **No Claude** | Green | Git pane with no Claude session running |
+| **No Git** | Default | Pane not in a git repository |
 
 **Detection Method** (terminal-based, simple & reliable):
 

--- a/plugins/claude-state-monitor/README.md
+++ b/plugins/claude-state-monitor/README.md
@@ -30,7 +30,7 @@ This plugin uses tmux's `pipe-pane` feature to stream pane output in real-time a
 |------|---------|
 | `state-detector.sh` | Per-pane stream processor. Receives piped output, detects state, updates visuals. |
 | `monitor-manager.sh` | Lifecycle manager. Attaches/detaches pipe-pane for Command Center panes. |
-| `get-pane-display.sh` | Helper for tmux pane-border-format. Looks up display file by pane index. |
+| `get-pane-display.sh` | Helper for tmux pane-border-format. Looks up display file by pane ID. |
 | `README.md` | This documentation |
 
 ## How It Works

--- a/plugins/claude-state-monitor/get-pane-display.sh
+++ b/plugins/claude-state-monitor/get-pane-display.sh
@@ -21,4 +21,14 @@ fi
 f="/tmp/claude-pane-display/$safe_id"
 [[ -f "$f" ]] && cat "$f" && exit 0
 
-echo ""
+# No display file found - detect git/Claude status as fallback
+dir=$(tmux display-message -p -t "$pane_id" '#{pane_current_path}' 2>/dev/null)
+dirname="${dir##*/}"
+
+# Check if it's a git repo
+branch=$(git -C "$dir" branch --show-current 2>/dev/null)
+if [[ -z "$branch" ]]; then
+    echo "#[fg=default]No Git | $dirname#[default]"
+else
+    echo "#[fg=green]No Claude | $dirname | $branch#[default]"
+fi

--- a/plugins/claude-state-monitor/hooks/state-tracker.sh
+++ b/plugins/claude-state-monitor/hooks/state-tracker.sh
@@ -150,7 +150,7 @@ MAPEOF
         fi
 
         # Write display file for pane-border-format (with color codes)
-        DISPLAY_STRING="#[fg=$COLOR]$PROJECT | $BRANCH#[default]"
+        DISPLAY_STRING="#[fg=$COLOR]$LABEL | $PROJECT | $BRANCH#[default]"
         SAFE_PANE_ID="${PANE_ID//\%/}"
         mkdir -p "$DISPLAY_DIR"
         echo "$DISPLAY_STRING" > "$DISPLAY_DIR/$SAFE_PANE_ID"

--- a/plugins/claude-state-monitor/state-detector.sh
+++ b/plugins/claude-state-monitor/state-detector.sh
@@ -165,7 +165,14 @@ write_display() {
         *)       color="$COLOR_WORKING" ;;
     esac
 
-    local display="#[fg=$color]$PROJECT | $BRANCH#[default]"
+    local label
+    case "$state" in
+        ready)   label="$LABEL_READY" ;;
+        working) label="$LABEL_WORKING" ;;
+        *)       label="$LABEL_WORKING" ;;
+    esac
+
+    local display="#[fg=$color]$label | $PROJECT | $BRANCH#[default]"
     local safe_id="${PANE_ID//\%/}"
     echo "$display" > "$DISPLAY_DIR/$safe_id"
 }

--- a/scripts/para-llm-restore.sh
+++ b/scripts/para-llm-restore.sh
@@ -83,7 +83,7 @@ MAPPING_EOF
 
         # Set initial pane title (will show "Starting..." until Claude hooks update it)
         SAFE_PANE_ID="${pane_id//\%/}"
-        echo "$project | $branch" > "$DISPLAY_DIR/$SAFE_PANE_ID"
+        echo "#[fg=yellow]Working | $project | $branch#[default]" > "$DISPLAY_DIR/$SAFE_PANE_ID"
 
         # Set initial border color to yellow (starting)
         tmux set-option -p -t "$pane_id" pane-border-style "fg=yellow" 2>/dev/null || true

--- a/tmux-command-center.sh
+++ b/tmux-command-center.sh
@@ -207,17 +207,17 @@ create_command_center() {
     # Enable pane border status to show window names at top of each tile
     tmux set-window-option -t "$COMMAND_CENTER" pane-border-status top
     # Use dynamic format that reads from display files written by the state monitor
-    # Helper script looks up pane_id by index and reads the corresponding display file
+    # Helper script looks up pane_id and reads the corresponding display file
     # #{?pane_active,** , } adds ** around active pane (handled by tmux, not script)
     local display_helper="$SCRIPT_DIR/plugins/claude-state-monitor/get-pane-display.sh"
     tmux set-window-option -t "$COMMAND_CENTER" pane-border-format \
-        "#{?pane_active,** , }#{pane_index}: #($display_helper #{pane_index})#{?pane_active, **,} "
+        "#{?pane_active,** , }#{pane_index}: #($display_helper #{pane_id})#{?pane_active, **,} "
 
     # Initialize display files with project | branch before monitor starts
     mkdir -p "$PANE_DISPLAY_DIR"
     while IFS='|' read -r pane_id name origin project; do
         local safe_id="${pane_id//\%/}"
-        echo "#[fg=green]${project} | ${name}#[default]" > "$PANE_DISPLAY_DIR/$safe_id"
+        echo "#[fg=green]Waiting for Input | ${project} | ${name}#[default]" > "$PANE_DISPLAY_DIR/$safe_id"
     done < "$STATE_FILE"
 
     # Select first pane

--- a/tmux-new-branch.sh
+++ b/tmux-new-branch.sh
@@ -48,8 +48,9 @@ create_feature_window() {
 
         # Initialize display file for the new pane
         local safe_id="${new_pane_id//\%/}"
-        mkdir -p /tmp/claude-pane-display
-        echo "Waiting for Input | $branch_name | $project_name" > "/tmp/claude-pane-display/$safe_id"
+        local display_dir="$PARA_LLM_ROOT/recovery/pane-display"
+        mkdir -p "$display_dir"
+        echo "#[fg=green]No Claude | $project_name | $branch_name#[default]" > "$display_dir/$safe_id"
 
         # Start state monitor for the new pane
         local monitor_script


### PR DESCRIPTION
## Summary
- Fix command center passing `#{pane_index}` instead of `#{pane_id}` to `get-pane-display.sh`, which caused display file lookups to match wrong panes or fall through to incorrect fallback data
- Standardize all 5 display-file writers to use consistent format: `#[fg=<color>]<status> | <directory> | <branch>#[default]`
- Add smart fallback in `get-pane-display.sh` for unmanaged panes: `No Git | <dir>` or `No Claude | <dir> | <branch>`

## Files changed
| File | Change |
|------|--------|
| `tmux-command-center.sh` | `#{pane_index}` → `#{pane_id}` in display helper call; add status+color to initial display |
| `get-pane-display.sh` | Fallback detects git/Claude → `No Git` or `No Claude` |
| `state-tracker.sh` | Add `$LABEL` to display string (was missing status prefix) |
| `state-detector.sh` | Add `#[fg=color]` and fix field order to `status \| project \| branch` |
| `para-llm-restore.sh` | Add `#[fg=yellow]Working \| ...` to initial display |
| `tmux-new-branch.sh` | Fix field order, add color, use bootstrap `$DISPLAY_DIR` |
| docs (2 files) | Update state tables with all 5 states and colors |

## Test plan
- [ ] Install from branch, open command center — titles should show consistent `status | project | branch` format
- [ ] Check non-managed pane shows `No Claude | dirname | branch` or `No Git | dirname`
- [ ] Check para-llm pane shows `Waiting for Input | project | branch` with green color
- [ ] Kill Claude in a pane — state-detector should show `Waiting for Input`

🤖 Generated with [Claude Code](https://claude.com/claude-code)