### PR TITLE
Set status-interval to 1s for responsive pane borders

### DIFF
--- a/.llm-context/topics/product-features.md
+++ b/.llm-context/topics/product-features.md
@@ -211,7 +211,7 @@ STATUS_LINE_PREFIX="CC"
 STATUS_LINE_EMOJI=1
 ```
 
-**Auto-refresh**: Status updates every 2 seconds via tmux's `status-interval`.
+**Auto-refresh**: Status updates every 1 second via tmux's `status-interval`.
 
 **Implementation**:
 - `plugins/claude-state-monitor/tmux-status.sh` - Reads state files and outputs formatted status

--- a/install.sh
+++ b/install.sh
@@ -290,7 +290,7 @@ bind-key R run-shell '$PARA_LLM_ROOT/scripts/para-llm-restore.sh'
 # Claude Code status in status line (shows aggregate state)
 # Appends to existing status-right, preserving user customizations
 set -ga status-right ' #($SCRIPT_DIR/plugins/claude-state-monitor/tmux-status.sh)'
-set -g status-interval 5
+set -g status-interval 1
 set -g status-right-length 120
 
 # Pane border titles (shows Claude state per pane)


### PR DESCRIPTION
## Summary
- Lower tmux `status-interval` from 5s to 1s so pane border titles update promptly when Claude state changes

## Test plan
- [ ] Open command center, trigger Claude work — title should update within ~1 second

🤖 Generated with [Claude Code](https://claude.com/claude-code)