### PR TITLE
Switch to instant @pane_display updates and fix state detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -295,7 +295,7 @@ set -g status-right-length 120
 
 # Pane border titles (shows Claude state per pane)
 set -g pane-border-status top
-set -g pane-border-format '#{?pane_active,#[reverse],} #{window_index}: #($SCRIPT_DIR/plugins/claude-state-monitor/get-pane-display.sh #{pane_id}) #{?pane_active,#[noreverse],}'
+set -g pane-border-format '#{?pane_active,#[reverse],} #{window_index}: #{@pane_display} #{?pane_active,#[noreverse],}'
 # end para-llm-directory
 EOF
 echo "Added bindings to ~/.tmux.conf"

--- a/scripts/para-llm-restore.sh
+++ b/scripts/para-llm-restore.sh
@@ -81,9 +81,8 @@ BRANCH=$branch
 CWD=$pane_path
 MAPPING_EOF
 
-        # Set initial pane title (will show "Starting..." until Claude hooks update it)
-        SAFE_PANE_ID="${pane_id//\%/}"
-        echo "#[fg=yellow]Working | $project | $branch#[default]" > "$DISPLAY_DIR/$SAFE_PANE_ID"
+        # Set initial pane title (will show until Claude hooks update it)
+        tmux set-option -p -t "$pane_id" @pane_display "#[fg=yellow]Working | $project | $branch#[default]" 2>/dev/null || true
 
         # Set initial border color to yellow (starting)
         tmux set-option -p -t "$pane_id" pane-border-style "fg=yellow" 2>/dev/null || true

--- a/tmux-new-branch.sh
+++ b/tmux-new-branch.sh
@@ -37,7 +37,7 @@ create_feature_window() {
         # Add to state file so it can be restored later
         local session_name
         session_name=$(tmux display-message -p '#{session_name}')
-        local state_file="/tmp/tmux-command-center-state-${session_name}"
+        local state_file="$PARA_LLM_ROOT/recovery/command-center-state-${session_name}"
         echo "$new_pane_id|$branch_name|new|$project_name" >> "$state_file"
 
         # Join pane to command center
@@ -46,11 +46,8 @@ create_feature_window() {
         # Reapply tiled layout
         tmux select-layout -t "$COMMAND_CENTER" tiled
 
-        # Initialize display file for the new pane
-        local safe_id="${new_pane_id//\%/}"
-        local display_dir="$PARA_LLM_ROOT/recovery/pane-display"
-        mkdir -p "$display_dir"
-        echo "#[fg=green]No Claude | $project_name | $branch_name#[default]" > "$display_dir/$safe_id"
+        # Initialize pane display option
+        tmux set-option -p -t "$new_pane_id" @pane_display "#[fg=green]No Claude | $project_name | $branch_name#[default]" 2>/dev/null || true
 
         # Start state monitor for the new pane
         local monitor_script


### PR DESCRIPTION
## Summary
- **Instant updates**: Replace file-based `#()` pane display (cached by tmux for `status-interval` seconds) with `@pane_display` pane options that update immediately when set
- **Fix state detection**: Detect Claude working state by checking for "esc to interrupt" in the status bar instead of unreliable `❯`/`⏵` prompt indicators that are always visible
- **Multi-repo CWD resolution**: Add env root fallback lookup so hooks work when Claude's CWD is a subdirectory of a multi-repo environment
- **Stale pane cleanup**: Validate pane IDs exist before using cached mappings, remove stale mapping files
- **Safe command center restore**: Break out untracked panes instead of killing them when closing command center
- **Fix state file path**: tmux-new-branch.sh now writes to `$PARA_LLM_ROOT/recovery/` instead of `/tmp/`

## Test plan
- [ ] Open command center, submit a prompt in a pane — title should switch to "Working" within ~0.3s
- [ ] Title shows detailed tool info ("Working: Bash") during tool calls via hooks
- [ ] Title returns to "Waiting for Input" when Claude finishes
- [ ] Multi-repo envs: hooks update correct pane when Claude works in subdirectories
- [ ] Close command center — all panes restored, none killed
- [ ] New branch via Ctrl+b n joins command center with correct state file path

🤖 Generated with [Claude Code](https://claude.com/claude-code)