### PR TITLE
Add remote workspace save/restore plugin

### DIFF
--- a/plugins/remote-save/backends/ssh.sh
+++ b/plugins/remote-save/backends/ssh.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# ssh.sh - SSH/rsync backend for remote save
+# Implements: backend_push, backend_pull, backend_test, backend_list
+#
+# Expected variables (sourced from remote config before calling):
+#   REMOTE_HOST      - SSH host (e.g., user@host)
+#   REMOTE_DIR       - Remote directory path
+#   REMOTE_SSH_KEY   - Optional SSH key path
+#   REMOTE_SSH_PORT  - Optional SSH port (default: 22)
+
+_ssh_opts() {
+    local opts=(-o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new)
+    if [[ -n "${REMOTE_SSH_KEY:-}" ]]; then
+        opts+=(-i "$REMOTE_SSH_KEY")
+    fi
+    if [[ -n "${REMOTE_SSH_PORT:-}" && "${REMOTE_SSH_PORT:-}" != "22" ]]; then
+        opts+=(-p "$REMOTE_SSH_PORT")
+    fi
+    echo "${opts[@]}"
+}
+
+_rsync_ssh_cmd() {
+    local cmd="ssh -o BatchMode=yes -o ConnectTimeout=5"
+    if [[ -n "${REMOTE_SSH_KEY:-}" ]]; then
+        cmd="$cmd -i $REMOTE_SSH_KEY"
+    fi
+    if [[ -n "${REMOTE_SSH_PORT:-}" && "${REMOTE_SSH_PORT:-}" != "22" ]]; then
+        cmd="$cmd -p $REMOTE_SSH_PORT"
+    fi
+    echo "$cmd"
+}
+
+_rsync_opts() {
+    local opts=(-az --timeout=10)
+    opts+=(-e "$(_rsync_ssh_cmd)")
+    echo "${opts[@]}"
+}
+
+backend_test() {
+    local ssh_opts
+    read -ra ssh_opts <<< "$(_ssh_opts)"
+    ssh "${ssh_opts[@]}" "$REMOTE_HOST" "mkdir -p '$REMOTE_DIR' && echo ok" 2>/dev/null
+    return $?
+}
+
+backend_push() {
+    local local_dir="$1"
+    local rsync_opts
+    read -ra rsync_opts <<< "$(_rsync_opts)"
+
+    # Ensure remote directory exists
+    local ssh_opts
+    read -ra ssh_opts <<< "$(_ssh_opts)"
+    ssh "${ssh_opts[@]}" "$REMOTE_HOST" "mkdir -p '$REMOTE_DIR'" 2>/dev/null || return 1
+
+    # Push files
+    rsync "${rsync_opts[@]}" "$local_dir/" "$REMOTE_HOST:$REMOTE_DIR/" 2>/dev/null
+    return $?
+}
+
+backend_pull() {
+    local local_dir="$1"
+    local rsync_opts
+    read -ra rsync_opts <<< "$(_rsync_opts)"
+
+    mkdir -p "$local_dir"
+    rsync "${rsync_opts[@]}" "$REMOTE_HOST:$REMOTE_DIR/" "$local_dir/" 2>/dev/null
+    return $?
+}
+
+backend_list() {
+    local ssh_opts
+    read -ra ssh_opts <<< "$(_ssh_opts)"
+    ssh "${ssh_opts[@]}" "$REMOTE_HOST" "ls -la '$REMOTE_DIR/' 2>/dev/null" 2>/dev/null
+    return $?
+}

--- a/plugins/remote-save/remote-manage.sh
+++ b/plugins/remote-save/remote-manage.sh
@@ -1,0 +1,492 @@
+#!/usr/bin/env bash
+# remote-manage.sh - fzf-based menu for managing remote save backends
+# Launched via Ctrl+b t (tmux display-popup)
+
+set -u
+
+# Read PARA_LLM_ROOT from bootstrap pointer
+BOOTSTRAP_FILE="$HOME/.para-llm-root"
+if [[ ! -f "$BOOTSTRAP_FILE" ]]; then
+    echo "para-llm: No bootstrap file found"
+    exit 1
+fi
+PARA_LLM_ROOT="$(cat "$BOOTSTRAP_FILE")"
+REMOTES_DIR="$PARA_LLM_ROOT/remotes"
+ACTIVE_FILE="$REMOTES_DIR/.active"
+
+# Source config
+if [[ -f "$PARA_LLM_ROOT/config" ]]; then
+    source "$PARA_LLM_ROOT/config"
+fi
+
+mkdir -p "$REMOTES_DIR"
+
+# --- Helper functions ---
+
+get_active_remote() {
+    if [[ -f "$ACTIVE_FILE" ]]; then
+        cat "$ACTIVE_FILE"
+    else
+        echo ""
+    fi
+}
+
+list_remotes() {
+    local active
+    active=$(get_active_remote)
+    for f in "$REMOTES_DIR"/*; do
+        [[ -f "$f" ]] || continue
+        local name
+        name=$(basename "$f")
+        [[ "$name" == ".active" ]] && continue
+        if [[ "$name" == "$active" ]]; then
+            echo "* $name"
+        else
+            echo "  $name"
+        fi
+    done
+}
+
+load_remote() {
+    local name="$1"
+    local remote_file="$REMOTES_DIR/$name"
+    if [[ -f "$remote_file" ]]; then
+        source "$remote_file"
+    fi
+}
+
+# --- Menu actions ---
+
+action_add() {
+    local REMOTE_BACKEND="ssh"
+    local REMOTE_NAME=""
+    local REMOTE_HOST=""
+    local REMOTE_SSH_KEY=""
+    local REMOTE_SSH_PORT=""
+    local REMOTE_DIR=""
+    local SOURCE=""
+    local step=1
+
+    while true; do
+        case $step in
+            1)
+                # Step 1: Remote name
+                echo ""
+                echo "Add new remote"
+                echo "=============="
+                echo ""
+                read -r -p "Remote name (e.g., my-server) [← empty to go back]: " REMOTE_NAME
+                [[ -z "$REMOTE_NAME" ]] && return
+                # Sanitize
+                REMOTE_NAME=$(echo "$REMOTE_NAME" | sed 's/[^a-zA-Z0-9_-]//g')
+                if [[ -z "$REMOTE_NAME" ]]; then
+                    echo "Invalid name."
+                    continue
+                fi
+                if [[ -f "$REMOTES_DIR/$REMOTE_NAME" ]]; then
+                    echo "Remote '$REMOTE_NAME' already exists."
+                    continue
+                fi
+                step=2
+                ;;
+            2)
+                # Step 2: Connection type
+                # Check for SSH config hosts
+                local SSH_HOSTS=""
+                if [[ -f "$HOME/.ssh/config" ]]; then
+                    SSH_HOSTS=$(awk '/^Host / && !/\*/ { print $2 }' "$HOME/.ssh/config" 2>/dev/null)
+                fi
+
+                local sources=""
+                if [[ -n "$SSH_HOSTS" ]]; then
+                    sources="SSH config host"
+                fi
+                sources="${sources:+$sources\n}Reverse tunnel (ssh -R)\nEnter manually\n← Back"
+
+                echo ""
+                SOURCE=$(printf "%b" "$sources" | fzf --prompt="Connection type: " --height=10 --no-info)
+                if [[ -z "$SOURCE" || "$SOURCE" == "← Back" ]]; then
+                    step=1; continue
+                fi
+
+                # Reset connection fields for fresh selection
+                REMOTE_HOST=""
+                REMOTE_SSH_KEY=""
+                REMOTE_SSH_PORT=""
+
+                case "$SOURCE" in
+                    "SSH config host")
+                        step=3
+                        ;;
+                    "Reverse tunnel (ssh -R)")
+                        step=4
+                        ;;
+                    "Enter manually")
+                        step=5
+                        ;;
+                esac
+                ;;
+            3)
+                # Step 3: SSH config host selection
+                echo ""
+                local SELECTED
+                SELECTED=$(printf "%s\n← Back" "$SSH_HOSTS" | fzf --prompt="SSH host: " --height=15)
+                if [[ -z "$SELECTED" || "$SELECTED" == "← Back" ]]; then
+                    step=2; continue
+                fi
+
+                # Resolve user, hostname, port, and identity file from ssh config
+                local ssh_resolved
+                ssh_resolved=$(ssh -G "$SELECTED" 2>/dev/null)
+                local SSH_USER SSH_HOSTNAME SSH_PORT SSH_IDENTITY
+                SSH_USER=$(echo "$ssh_resolved" | awk '/^user / { print $2 }')
+                SSH_HOSTNAME=$(echo "$ssh_resolved" | awk '/^hostname / { print $2 }')
+                SSH_PORT=$(echo "$ssh_resolved" | awk '/^port / { print $2 }')
+                SSH_IDENTITY=$(echo "$ssh_resolved" | awk '/^identityfile / { print $2; exit }')
+
+                if [[ -n "$SSH_USER" && "$SSH_USER" != "$(whoami)" ]]; then
+                    REMOTE_HOST="${SSH_USER}@${SSH_HOSTNAME:-$SELECTED}"
+                else
+                    REMOTE_HOST="${SSH_HOSTNAME:-$SELECTED}"
+                fi
+
+                if [[ -n "$SSH_PORT" && "$SSH_PORT" != "22" ]]; then
+                    REMOTE_SSH_PORT="$SSH_PORT"
+                fi
+
+                if [[ -n "$SSH_IDENTITY" ]]; then
+                    SSH_IDENTITY="${SSH_IDENTITY/#\~/$HOME}"
+                    if [[ -f "$SSH_IDENTITY" ]]; then
+                        REMOTE_SSH_KEY="$SSH_IDENTITY"
+                    fi
+                fi
+
+                echo "  Host: $REMOTE_HOST"
+                [[ -n "$REMOTE_SSH_PORT" ]] && echo "  Port: $REMOTE_SSH_PORT"
+                [[ -n "$REMOTE_SSH_KEY" ]] && echo "  Key: $REMOTE_SSH_KEY"
+                step=6
+                ;;
+            4)
+                # Step 4: Reverse tunnel
+                echo ""
+
+                # Check if we're in an SSH session
+                if [[ -z "${SSH_CONNECTION:-}" && -z "${SSH_CLIENT:-}" ]]; then
+                    echo "Not in an SSH session."
+                    echo ""
+                    echo "Reverse tunnels require you to be SSH'd into this machine."
+                    echo "From your local machine, connect with:"
+                    echo "  ssh -R <port>:localhost:22 <this-host>"
+                    echo ""
+                    read -r -p "Press Enter to go back..."
+                    step=2; continue
+                fi
+
+                # Detect active reverse tunnels
+                local REVERSE_TUNNELS=""
+                if command -v lsof &>/dev/null; then
+                    REVERSE_TUNNELS=$(lsof -i -n -P 2>/dev/null | grep "sshd" | grep "LISTEN" | \
+                        awk '{ print $9 }' | sed 's/.*://' | sort -un | grep -v "^22$")
+                elif command -v ss &>/dev/null; then
+                    REVERSE_TUNNELS=$(ss -tlnp 2>/dev/null | grep "sshd" | \
+                        awk '{ print $4 }' | sed 's/.*://' | sort -un | grep -v "^22$")
+                fi
+
+                if [[ -z "$REVERSE_TUNNELS" ]]; then
+                    local CLIENT_IP="${SSH_CONNECTION%% *}"
+                    echo "SSH session detected (from $CLIENT_IP), but no reverse tunnels found."
+                    echo ""
+                    echo "Your SSH session was not started with a reverse port forward."
+                    echo "Reconnect with:"
+                    echo "  ssh -R <port>:localhost:22 <this-host>"
+                    echo ""
+                    echo "Example:"
+                    echo "  ssh -R 2222:localhost:22 $(whoami)@$(hostname)"
+                    echo ""
+                    read -r -p "Press Enter to go back..."
+                    step=2; continue
+                fi
+
+                # Pick tunnel port
+                echo "Detected reverse tunnel ports:"
+                local TUNNEL_PORT
+                TUNNEL_PORT=$(printf "%s\n← Back" "$REVERSE_TUNNELS" | fzf --prompt="Select tunnel port: " --height=10)
+                if [[ -z "$TUNNEL_PORT" || "$TUNNEL_PORT" == "← Back" ]]; then
+                    step=2; continue
+                fi
+
+                REMOTE_HOST="localhost"
+                REMOTE_SSH_PORT="$TUNNEL_PORT"
+
+                read -r -p "Username on originating machine [$(whoami)] [← empty to go back]: " TUNNEL_USER
+                if [[ "$TUNNEL_USER" == "" ]]; then
+                    # Empty means accept default, not go back - use a sentinel
+                    TUNNEL_USER="$(whoami)"
+                fi
+                if [[ "$TUNNEL_USER" != "$(whoami)" ]]; then
+                    REMOTE_HOST="${TUNNEL_USER}@localhost"
+                fi
+
+                echo "  Using: ssh -p $REMOTE_SSH_PORT $REMOTE_HOST"
+                step=6
+                ;;
+            5)
+                # Step 5: Manual entry
+                echo ""
+                read -r -p "SSH host (e.g., user@host) [← empty to go back]: " REMOTE_HOST
+                if [[ -z "$REMOTE_HOST" ]]; then
+                    step=2; continue
+                fi
+
+                read -r -p "SSH port [22]: " REMOTE_SSH_PORT
+                REMOTE_SSH_PORT="${REMOTE_SSH_PORT:-}"
+                [[ "$REMOTE_SSH_PORT" == "22" ]] && REMOTE_SSH_PORT=""
+
+                read -r -p "SSH key path (optional, leave empty for default): " REMOTE_SSH_KEY
+                step=6
+                ;;
+            6)
+                # Step 6: Remote directory
+                local REMOTE_USER="${REMOTE_HOST%%@*}"
+                if [[ "$REMOTE_USER" == "$REMOTE_HOST" ]]; then
+                    REMOTE_USER="$(whoami)"
+                fi
+
+                echo ""
+                read -r -p "Remote directory [/home/${REMOTE_USER}/.para-llm-remote] [← 'back' to go back]: " REMOTE_DIR
+                if [[ "$REMOTE_DIR" == "back" ]]; then
+                    REMOTE_DIR=""
+                    # Go back to the connection type step
+                    step=2; continue
+                fi
+                REMOTE_DIR="${REMOTE_DIR:-/home/${REMOTE_USER}/.para-llm-remote}"
+                step=7
+                ;;
+            7)
+                # Step 7: Confirm and save
+                echo ""
+                echo "Remote configuration:"
+                echo "  Name:      $REMOTE_NAME"
+                echo "  Host:      $REMOTE_HOST"
+                [[ -n "$REMOTE_SSH_PORT" ]] && echo "  Port:      $REMOTE_SSH_PORT"
+                [[ -n "$REMOTE_SSH_KEY" ]] && echo "  Key:       $REMOTE_SSH_KEY"
+                echo "  Directory: $REMOTE_DIR"
+                echo ""
+
+                local confirm
+                confirm=$(printf "Save\n← Back\nCancel" | fzf --prompt="Confirm: " --height=5 --no-info)
+                case "$confirm" in
+                    "Save")
+                        ;;
+                    "← Back")
+                        step=6; continue
+                        ;;
+                    *)
+                        return
+                        ;;
+                esac
+
+                # Write remote config file
+                cat > "$REMOTES_DIR/$REMOTE_NAME" << REMOTE_EOF
+# para-llm remote: $REMOTE_NAME
+REMOTE_BACKEND="$REMOTE_BACKEND"
+REMOTE_HOST="$REMOTE_HOST"
+REMOTE_DIR="$REMOTE_DIR"
+REMOTE_SSH_KEY="${REMOTE_SSH_KEY:-}"
+REMOTE_SSH_PORT="${REMOTE_SSH_PORT:-}"
+REMOTE_EOF
+
+                echo ""
+                echo "Remote '$REMOTE_NAME' created."
+
+                # Set as active if it's the only one
+                local count
+                count=$(list_remotes | wc -l | tr -d ' ')
+                if [[ "$count" -eq 1 ]]; then
+                    echo "$REMOTE_NAME" > "$ACTIVE_FILE"
+                    echo "Set as active remote."
+                fi
+
+                # Offer to test
+                read -r -p "Test connection now? [Y/n]: " test_choice
+                if [[ ! "$test_choice" =~ ^[Nn] ]]; then
+                    action_test "$REMOTE_NAME"
+                fi
+                return
+                ;;
+        esac
+    done
+}
+
+action_remove() {
+    local remotes
+    remotes=$(list_remotes)
+    if [[ -z "$remotes" ]]; then
+        echo "No remotes configured."
+        read -r -p "Press Enter to continue..."
+        return
+    fi
+
+    echo ""
+    echo "Remove remote"
+    echo "============="
+    local selected
+    selected=$(printf "%s\n← Back" "$remotes" | fzf --prompt="Select remote to remove: " --height=10)
+    [[ -z "$selected" || "$selected" == "← Back" ]] && return
+
+    # Strip leading marker
+    local name
+    name=$(echo "$selected" | sed 's/^[* ] //')
+
+    read -r -p "Remove remote '$name'? [y/N]: " confirm
+    if [[ "$confirm" =~ ^[Yy] ]]; then
+        rm -f "$REMOTES_DIR/$name"
+        # Clear active if this was the active remote
+        if [[ "$(get_active_remote)" == "$name" ]]; then
+            rm -f "$ACTIVE_FILE"
+        fi
+        echo "Remote '$name' removed."
+    fi
+}
+
+action_select() {
+    local remotes
+    remotes=$(list_remotes)
+    if [[ -z "$remotes" ]]; then
+        echo "No remotes configured."
+        read -r -p "Press Enter to continue..."
+        return
+    fi
+
+    echo ""
+    echo "Select active remote"
+    echo "===================="
+    local selected
+    selected=$(printf "%s\n← Back" "$remotes" | fzf --prompt="Select active remote: " --height=10)
+    [[ -z "$selected" || "$selected" == "← Back" ]] && return
+
+    local name
+    name=$(echo "$selected" | sed 's/^[* ] //')
+    echo "$name" > "$ACTIVE_FILE"
+    echo "Active remote set to '$name'."
+}
+
+action_test() {
+    local name="${1:-}"
+
+    if [[ -z "$name" ]]; then
+        local remotes
+        remotes=$(list_remotes)
+        if [[ -z "$remotes" ]]; then
+            echo "No remotes configured."
+            read -r -p "Press Enter to continue..."
+            return
+        fi
+
+        echo ""
+        local selected
+        selected=$(printf "%s\n← Back" "$remotes" | fzf --prompt="Select remote to test: " --height=10)
+        [[ -z "$selected" || "$selected" == "← Back" ]] && return
+        name=$(echo "$selected" | sed 's/^[* ] //')
+    fi
+
+    echo ""
+    echo "Testing remote '$name'..."
+    load_remote "$name"
+
+    # Find and source the backend
+    local SCRIPT_DIR
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    local backend_file="$SCRIPT_DIR/backends/${REMOTE_BACKEND}.sh"
+    if [[ ! -f "$backend_file" ]]; then
+        echo "ERROR: Backend '${REMOTE_BACKEND}' not found at $backend_file"
+        return 1
+    fi
+    source "$backend_file"
+
+    if backend_test; then
+        echo "Connection successful!"
+    else
+        echo "Connection FAILED."
+    fi
+}
+
+action_toggle() {
+    local current="${REMOTE_SAVE_ENABLED:-1}"
+    local new_state
+    if [[ "$current" == "1" ]]; then
+        new_state="0"
+        echo "Automatic updates: DISABLED"
+    else
+        # Check we have an active remote
+        local active
+        active=$(get_active_remote)
+        if [[ -z "$active" ]]; then
+            echo "No active remote configured. Add a remote first."
+            read -r -p "Press Enter to continue..."
+            return
+        fi
+        new_state="1"
+        echo "Automatic updates: ENABLED (using '$active')"
+    fi
+
+    # Update config file
+    if grep -q "^REMOTE_SAVE_ENABLED=" "$PARA_LLM_ROOT/config" 2>/dev/null; then
+        sed -i.tmp "s/^REMOTE_SAVE_ENABLED=.*/REMOTE_SAVE_ENABLED=$new_state/" "$PARA_LLM_ROOT/config"
+        rm -f "$PARA_LLM_ROOT/config.tmp"
+    else
+        echo "" >> "$PARA_LLM_ROOT/config"
+        echo "# Remote save (push state to remote on each save cycle)" >> "$PARA_LLM_ROOT/config"
+        echo "REMOTE_SAVE_ENABLED=$new_state" >> "$PARA_LLM_ROOT/config"
+    fi
+}
+
+# --- Main menu ---
+
+while true; do
+    echo ""
+    echo "Para-LLM Remote Management"
+    echo "=========================="
+
+    active=$(get_active_remote)
+    status="${REMOTE_SAVE_ENABLED:-1}"
+    if [[ "$status" == "1" ]]; then
+        echo "Auto-updates: ON | Active: ${active:-none}"
+    else
+        echo "Auto-updates: OFF | Active: ${active:-none}"
+    fi
+
+    echo ""
+    remotes=$(list_remotes)
+    if [[ -n "$remotes" ]]; then
+        echo "Configured remotes:"
+        echo "$remotes"
+    else
+        echo "No remotes configured."
+    fi
+    echo ""
+
+    # Dynamic label for toggle
+    if [[ "$status" == "1" ]]; then
+        toggle_label="Disable automatic updates"
+    else
+        toggle_label="Enable automatic updates"
+    fi
+
+    ACTION=$(printf "Add remote\nRemove remote\nSelect active\nTest connection\n%s\nExit" "$toggle_label" | \
+        fzf --prompt="Action: " --height=10 --no-info)
+
+    case "$ACTION" in
+        "Add remote")       action_add ;;
+        "Remove remote")    action_remove ;;
+        "Select active")    action_select ;;
+        "Test connection")  action_test ;;
+        "Enable automatic updates"|"Disable automatic updates") action_toggle ;;
+        "Exit"|"")          exit 0 ;;
+    esac
+
+    # Re-source config in case toggle changed it
+    if [[ -f "$PARA_LLM_ROOT/config" ]]; then
+        source "$PARA_LLM_ROOT/config"
+    fi
+done

--- a/plugins/remote-save/remote-manage.sh
+++ b/plugins/remote-save/remote-manage.sh
@@ -2,6 +2,17 @@
 # remote-manage.sh - fzf-based menu for managing remote save backends
 # Launched via Ctrl+b t (tmux display-popup)
 
+# Source user profile for PATH (fzf may be installed in ~/.fzf/bin)
+# tmux display-popup runs non-interactive shell, so .bashrc isn't loaded
+# NOTE: set -u must come AFTER sourcing, as bashrc may reference unset variables
+if [[ -f "$HOME/.bashrc" ]]; then
+    source "$HOME/.bashrc" 2>/dev/null || true
+elif [[ -f "$HOME/.bash_profile" ]]; then
+    source "$HOME/.bash_profile" 2>/dev/null || true
+elif [[ -f "$HOME/.profile" ]]; then
+    source "$HOME/.profile" 2>/dev/null || true
+fi
+
 set -u
 
 # Read PARA_LLM_ROOT from bootstrap pointer
@@ -22,6 +33,50 @@ fi
 mkdir -p "$REMOTES_DIR"
 
 # --- Helper functions ---
+
+# Read a line of input with Escape-to-go-back support
+# Usage: read_input "prompt: " [default]
+# Returns 0 on success (result in REPLY), 1 on Escape (go back)
+read_input() {
+    local prompt="$1"
+    local default="${2:-}"
+    REPLY=""
+
+    printf "%s" "$prompt"
+
+    while true; do
+        IFS= read -r -s -n 1 ch
+
+        # Escape key (ASCII 27)
+        if [[ "$ch" == $'\e' ]]; then
+            # Consume any trailing escape sequence chars (arrow keys, etc.)
+            read -r -s -n 2 -t 0.1 _ 2>/dev/null || true
+            echo ""
+            return 1
+        fi
+
+        # Enter key
+        if [[ "$ch" == "" ]]; then
+            echo ""
+            if [[ -z "$REPLY" && -n "$default" ]]; then
+                REPLY="$default"
+            fi
+            return 0
+        fi
+
+        # Backspace (ASCII 127 or 8)
+        if [[ "$ch" == $'\177' || "$ch" == $'\b' ]]; then
+            if [[ -n "$REPLY" ]]; then
+                REPLY="${REPLY%?}"
+                printf '\b \b'
+            fi
+            continue
+        fi
+
+        REPLY+="$ch"
+        printf "%s" "$ch"
+    done
+}
 
 get_active_remote() {
     if [[ -f "$ACTIVE_FILE" ]]; then
@@ -72,10 +127,11 @@ action_add() {
             1)
                 # Step 1: Remote name
                 echo ""
-                echo "Add new remote"
+                echo "Add new remote  (Esc to go back)"
                 echo "=============="
                 echo ""
-                read -r -p "Remote name (e.g., my-server) [← empty to go back]: " REMOTE_NAME
+                read_input "Remote name (e.g., my-server): " || return
+                REMOTE_NAME="$REPLY"
                 [[ -z "$REMOTE_NAME" ]] && return
                 # Sanitize
                 REMOTE_NAME=$(echo "$REMOTE_NAME" | sed 's/[^a-zA-Z0-9_-]//g')
@@ -178,18 +234,23 @@ action_add() {
                     echo "From your local machine, connect with:"
                     echo "  ssh -R <port>:localhost:22 <this-host>"
                     echo ""
-                    read -r -p "Press Enter to go back..."
+                    read -r -p "Press Enter or Esc to go back..."
                     step=2; continue
                 fi
 
                 # Detect active reverse tunnels
+                # Reverse tunnels show up as localhost-bound listeners on non-standard ports
+                # Try multiple methods since permissions vary (sshd runs as root)
                 local REVERSE_TUNNELS=""
-                if command -v lsof &>/dev/null; then
+                if command -v ss &>/dev/null; then
+                    # ss works without root for listing ports; filter localhost listeners
+                    # excluding well-known ports (22, 80, 443, etc.)
+                    REVERSE_TUNNELS=$(ss -tln 2>/dev/null | grep -E '127\.0\.0\.1:|::1\]:' | \
+                        awk '{ split($4, a, ":"); print a[length(a)] }' | \
+                        sort -un | grep -v '^22$' | awk '$1 > 1023')
+                elif command -v lsof &>/dev/null; then
                     REVERSE_TUNNELS=$(lsof -i -n -P 2>/dev/null | grep "sshd" | grep "LISTEN" | \
                         awk '{ print $9 }' | sed 's/.*://' | sort -un | grep -v "^22$")
-                elif command -v ss &>/dev/null; then
-                    REVERSE_TUNNELS=$(ss -tlnp 2>/dev/null | grep "sshd" | \
-                        awk '{ print $4 }' | sed 's/.*://' | sort -un | grep -v "^22$")
                 fi
 
                 if [[ -z "$REVERSE_TUNNELS" ]]; then
@@ -203,7 +264,7 @@ action_add() {
                     echo "Example:"
                     echo "  ssh -R 2222:localhost:22 $(whoami)@$(hostname)"
                     echo ""
-                    read -r -p "Press Enter to go back..."
+                    read -r -p "Press Enter or Esc to go back..."
                     step=2; continue
                 fi
 
@@ -218,31 +279,24 @@ action_add() {
                 REMOTE_HOST="localhost"
                 REMOTE_SSH_PORT="$TUNNEL_PORT"
 
-                read -r -p "Username on originating machine [$(whoami)] [← empty to go back]: " TUNNEL_USER
-                if [[ "$TUNNEL_USER" == "" ]]; then
-                    # Empty means accept default, not go back - use a sentinel
-                    TUNNEL_USER="$(whoami)"
-                fi
-                if [[ "$TUNNEL_USER" != "$(whoami)" ]]; then
-                    REMOTE_HOST="${TUNNEL_USER}@localhost"
-                fi
-
-                echo "  Using: ssh -p $REMOTE_SSH_PORT $REMOTE_HOST"
+                echo "  Using: ssh -p $REMOTE_SSH_PORT localhost"
                 step=6
                 ;;
             5)
                 # Step 5: Manual entry
                 echo ""
-                read -r -p "SSH host (e.g., user@host) [← empty to go back]: " REMOTE_HOST
+                read_input "SSH host (e.g., user@host): " || { step=2; continue; }
+                REMOTE_HOST="$REPLY"
                 if [[ -z "$REMOTE_HOST" ]]; then
                     step=2; continue
                 fi
 
-                read -r -p "SSH port [22]: " REMOTE_SSH_PORT
-                REMOTE_SSH_PORT="${REMOTE_SSH_PORT:-}"
+                read_input "SSH port [22]: " "22" || { step=2; continue; }
+                REMOTE_SSH_PORT="$REPLY"
                 [[ "$REMOTE_SSH_PORT" == "22" ]] && REMOTE_SSH_PORT=""
 
-                read -r -p "SSH key path (optional, leave empty for default): " REMOTE_SSH_KEY
+                read_input "SSH key path (optional, Enter to skip): " || { step=2; continue; }
+                REMOTE_SSH_KEY="$REPLY"
                 step=6
                 ;;
             6)
@@ -253,13 +307,9 @@ action_add() {
                 fi
 
                 echo ""
-                read -r -p "Remote directory [/home/${REMOTE_USER}/.para-llm-remote] [← 'back' to go back]: " REMOTE_DIR
-                if [[ "$REMOTE_DIR" == "back" ]]; then
-                    REMOTE_DIR=""
-                    # Go back to the connection type step
-                    step=2; continue
-                fi
-                REMOTE_DIR="${REMOTE_DIR:-/home/${REMOTE_USER}/.para-llm-remote}"
+                local default_dir="/home/${REMOTE_USER}/.para-llm-remote"
+                read_input "Remote directory [$default_dir]: " "$default_dir" || { step=2; continue; }
+                REMOTE_DIR="$REPLY"
                 step=7
                 ;;
             7)
@@ -308,7 +358,8 @@ REMOTE_EOF
                 fi
 
                 # Offer to test
-                read -r -p "Test connection now? [Y/n]: " test_choice
+                read_input "Test connection now? [Y/n]: " "y" || return
+                test_choice="$REPLY"
                 if [[ ! "$test_choice" =~ ^[Nn] ]]; then
                     action_test "$REMOTE_NAME"
                 fi

--- a/plugins/remote-save/remote-pull.sh
+++ b/plugins/remote-save/remote-pull.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# remote-pull.sh - Pull state files from active remote to local recovery
+# Used before remote restore to fetch latest state
+
+set -u
+
+# Read PARA_LLM_ROOT from bootstrap pointer
+BOOTSTRAP_FILE="$HOME/.para-llm-root"
+if [[ ! -f "$BOOTSTRAP_FILE" ]]; then
+    echo "para-llm: No bootstrap file found"
+    exit 1
+fi
+PARA_LLM_ROOT="$(cat "$BOOTSTRAP_FILE")"
+
+# Source config
+if [[ -f "$PARA_LLM_ROOT/config" ]]; then
+    source "$PARA_LLM_ROOT/config"
+fi
+
+REMOTES_DIR="$PARA_LLM_ROOT/remotes"
+ACTIVE_FILE="$REMOTES_DIR/.active"
+
+# Check active remote
+if [[ ! -f "$ACTIVE_FILE" ]]; then
+    echo "No active remote configured."
+    exit 1
+fi
+ACTIVE_REMOTE=$(cat "$ACTIVE_FILE")
+REMOTE_FILE="$REMOTES_DIR/$ACTIVE_REMOTE"
+if [[ ! -f "$REMOTE_FILE" ]]; then
+    echo "Remote config '$ACTIVE_REMOTE' not found."
+    exit 1
+fi
+
+# Load remote config and backend
+source "$REMOTE_FILE"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_FILE="$SCRIPT_DIR/backends/${REMOTE_BACKEND}.sh"
+if [[ ! -f "$BACKEND_FILE" ]]; then
+    echo "Backend '${REMOTE_BACKEND}' not found."
+    exit 1
+fi
+source "$BACKEND_FILE"
+
+# Pull to recovery directory
+PULL_DIR="$PARA_LLM_ROOT/recovery"
+mkdir -p "$PULL_DIR"
+
+echo "Pulling state from remote '$ACTIVE_REMOTE'..."
+if backend_pull "$PULL_DIR"; then
+    echo "Pull complete."
+    if [[ -f "$PULL_DIR/session-state" ]]; then
+        echo ""
+        echo "Session state:"
+        grep -v "^#" "$PULL_DIR/session-state" | grep -v "^window_name" | while IFS='|' read -r win ppath proj branch claude remote_url; do
+            echo "  $proj/$branch (claude=$claude)"
+        done
+    fi
+else
+    echo "Pull failed."
+    exit 1
+fi

--- a/plugins/remote-save/remote-restore-full.sh
+++ b/plugins/remote-save/remote-restore-full.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# remote-restore-full.sh - Full orchestrator for remote restore
+# 1. Pulls state from remote (if not already pulled)
+# 2. For each entry: git clone from git_remote
+# 3. git checkout branch
+# 4. Creates tmux window
+# 5. Launches Claude with --dangerously-skip-permissions --resume if it was running
+
+set -u
+
+# Read PARA_LLM_ROOT from bootstrap pointer
+BOOTSTRAP_FILE="$HOME/.para-llm-root"
+if [[ ! -f "$BOOTSTRAP_FILE" ]]; then
+    echo "para-llm: No bootstrap file found"
+    exit 1
+fi
+PARA_LLM_ROOT="$(cat "$BOOTSTRAP_FILE")"
+
+# Source config
+if [[ -f "$PARA_LLM_ROOT/config" ]]; then
+    source "$PARA_LLM_ROOT/config"
+fi
+
+ENVS_DIR="$PARA_LLM_ROOT/envs"
+STATE_FILE="$PARA_LLM_ROOT/recovery/session-state"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOG_FILE="$PARA_LLM_ROOT/recovery/remote-restore.log"
+
+mkdir -p "$ENVS_DIR"
+
+# Pull from remote first if state file doesn't exist
+if [[ ! -f "$STATE_FILE" ]]; then
+    echo "No local state found. Pulling from remote..."
+    "$SCRIPT_DIR/remote-pull.sh" || exit 1
+fi
+
+if [[ ! -f "$STATE_FILE" ]]; then
+    echo "No session state available after pull."
+    exit 1
+fi
+
+{
+    echo "=== Remote restore started: $(date -u +"%Y-%m-%dT%H:%M:%S") ==="
+} >> "$LOG_FILE"
+
+# Process each entry
+RESTORED=0
+SKIPPED=0
+FAILED=0
+
+while IFS='|' read -r win_name pane_path project branch had_claude git_remote; do
+    # Skip comments and header
+    [[ "$win_name" =~ ^# ]] && continue
+    [[ "$win_name" == "window_name" ]] && continue
+
+    echo ""
+    echo "Processing: $project/$branch"
+
+    # Determine env directory
+    ENV_NAME="${project}-${branch}"
+    ENV_DIR="$ENVS_DIR/$ENV_NAME"
+    PROJECT_DIR="$ENV_DIR/$project"
+
+    # Clone if directory doesn't exist
+    if [[ ! -d "$PROJECT_DIR" ]]; then
+        if [[ -z "$git_remote" ]]; then
+            echo "  SKIP: No git remote URL for $project/$branch"
+            echo "  SKIP $project/$branch: no git_remote" >> "$LOG_FILE"
+            SKIPPED=$((SKIPPED + 1))
+            continue
+        fi
+
+        echo "  Cloning from $git_remote..."
+        mkdir -p "$ENV_DIR"
+        if ! git clone "$git_remote" "$PROJECT_DIR" 2>&1; then
+            echo "  FAILED: Clone failed for $project/$branch"
+            echo "  FAILED $project/$branch: clone failed" >> "$LOG_FILE"
+            FAILED=$((FAILED + 1))
+            continue
+        fi
+
+        # Checkout branch
+        if [[ "$branch" != "main" && "$branch" != "master" ]]; then
+            echo "  Checking out branch: $branch"
+            if ! git -C "$PROJECT_DIR" checkout "$branch" 2>&1; then
+                # Try fetching and checking out as remote tracking branch
+                git -C "$PROJECT_DIR" fetch origin "$branch" 2>/dev/null
+                if ! git -C "$PROJECT_DIR" checkout -b "$branch" "origin/$branch" 2>&1; then
+                    echo "  WARNING: Could not checkout branch $branch, staying on default"
+                    echo "  WARN $project/$branch: branch checkout failed" >> "$LOG_FILE"
+                fi
+            fi
+        fi
+
+        # Run setup script if present
+        SETUP_SCRIPT="$PROJECT_DIR/paraLlm_setup.sh"
+        if [[ -f "$SETUP_SCRIPT" && -x "$SETUP_SCRIPT" ]]; then
+            echo "  Running setup script..."
+            (cd "$PROJECT_DIR" && ./paraLlm_setup.sh) 2>&1 || true
+        fi
+    else
+        echo "  Directory already exists, skipping clone."
+    fi
+
+    # Create tmux window
+    echo "  Creating tmux window: $win_name"
+    tmux new-window -n "$win_name" -c "$PROJECT_DIR" 2>/dev/null || {
+        echo "  FAILED: Could not create tmux window"
+        echo "  FAILED $project/$branch: tmux window creation" >> "$LOG_FILE"
+        FAILED=$((FAILED + 1))
+        continue
+    }
+
+    # Launch Claude if it was running
+    if [[ "$had_claude" == "true" ]]; then
+        echo "  Launching Claude..."
+        # Determine launch command
+        SETUP_SCRIPT="$PROJECT_DIR/paraLlm_setup.sh"
+        if [[ -f "$SETUP_SCRIPT" ]]; then
+            LAUNCH_CMD="./paraLlm_setup.sh && claude --dangerously-skip-permissions --resume"
+        else
+            LAUNCH_CMD="claude --dangerously-skip-permissions --resume"
+        fi
+        tmux send-keys -t "$win_name" "$LAUNCH_CMD" Enter
+    fi
+
+    echo "  RESTORED $project/$branch"
+    echo "  RESTORED $project/$branch" >> "$LOG_FILE"
+    RESTORED=$((RESTORED + 1))
+
+    # Brief pause between operations
+    sleep 0.5
+done < "$STATE_FILE"
+
+echo ""
+echo "Remote restore complete: restored=$RESTORED skipped=$SKIPPED failed=$FAILED"
+echo "  Summary: restored=$RESTORED skipped=$SKIPPED failed=$FAILED" >> "$LOG_FILE"
+
+tmux display-message "para-llm: Remote restored $RESTORED session(s), skipped $SKIPPED, failed $FAILED"

--- a/plugins/remote-save/remote-save.sh
+++ b/plugins/remote-save/remote-save.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# remote-save.sh - Push workspace state to active remote
+# Called at end of para-llm-save-state.sh (backgrounded, non-blocking)
+# Piggybacks on 1-minute tmux-resurrect save cycle
+
+set -u
+
+# Read PARA_LLM_ROOT from bootstrap pointer
+BOOTSTRAP_FILE="$HOME/.para-llm-root"
+if [[ ! -f "$BOOTSTRAP_FILE" ]]; then
+    exit 0
+fi
+PARA_LLM_ROOT="$(cat "$BOOTSTRAP_FILE")"
+
+# Source config
+if [[ -f "$PARA_LLM_ROOT/config" ]]; then
+    source "$PARA_LLM_ROOT/config"
+fi
+
+# Exit if remote save is disabled
+if [[ "${REMOTE_SAVE_ENABLED:-1}" != "1" ]]; then
+    exit 0
+fi
+
+REMOTES_DIR="$PARA_LLM_ROOT/remotes"
+ACTIVE_FILE="$REMOTES_DIR/.active"
+
+# Exit if no active remote
+if [[ ! -f "$ACTIVE_FILE" ]]; then
+    exit 0
+fi
+ACTIVE_REMOTE=$(cat "$ACTIVE_FILE")
+REMOTE_FILE="$REMOTES_DIR/$ACTIVE_REMOTE"
+if [[ ! -f "$REMOTE_FILE" ]]; then
+    exit 0
+fi
+
+# Prevent concurrent runs
+LOCK_FILE="/tmp/para-llm-remote-save.lock"
+if [[ -f "$LOCK_FILE" ]]; then
+    # Check if lock is stale (older than 60 seconds)
+    if [[ "$(uname)" == "Darwin" ]]; then
+        LOCK_AGE=$(( $(date +%s) - $(stat -f %m "$LOCK_FILE") ))
+    else
+        LOCK_AGE=$(( $(date +%s) - $(stat -c %Y "$LOCK_FILE") ))
+    fi
+    if [[ $LOCK_AGE -lt 60 ]]; then
+        exit 0
+    fi
+fi
+echo $$ > "$LOCK_FILE"
+trap 'rm -f "$LOCK_FILE"' EXIT
+
+# Load remote config
+source "$REMOTE_FILE"
+
+# Load backend
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_FILE="$SCRIPT_DIR/backends/${REMOTE_BACKEND}.sh"
+if [[ ! -f "$BACKEND_FILE" ]]; then
+    exit 1
+fi
+source "$BACKEND_FILE"
+
+# Stage files to push
+STAGING_DIR=$(mktemp -d)
+trap 'rm -rf "$STAGING_DIR"; rm -f "$LOCK_FILE"' EXIT
+
+# Copy session-state
+if [[ -f "$PARA_LLM_ROOT/recovery/session-state" ]]; then
+    cp "$PARA_LLM_ROOT/recovery/session-state" "$STAGING_DIR/"
+fi
+
+# Copy config
+if [[ -f "$PARA_LLM_ROOT/config" ]]; then
+    cp "$PARA_LLM_ROOT/config" "$STAGING_DIR/"
+fi
+
+# Push to remote
+backend_push "$STAGING_DIR"

--- a/scripts/para-llm-recovery-prompt.sh
+++ b/scripts/para-llm-recovery-prompt.sh
@@ -11,16 +11,41 @@ if [[ ! -f "$BOOTSTRAP_FILE" ]]; then
 fi
 PARA_LLM_ROOT="$(cat "$BOOTSTRAP_FILE")"
 
-STATE_FILE="$PARA_LLM_ROOT/recovery/session-state"
+# Source config for INSTALL_DIR
+if [[ -f "$PARA_LLM_ROOT/config" ]]; then
+    source "$PARA_LLM_ROOT/config"
+fi
 
-# Exit silently if no recovery state exists
+STATE_FILE="$PARA_LLM_ROOT/recovery/session-state"
+REMOTES_DIR="$PARA_LLM_ROOT/remotes"
+ACTIVE_FILE="$REMOTES_DIR/.active"
+
+# Check if a remote is configured
+HAS_REMOTE=false
+if [[ -f "$ACTIVE_FILE" ]]; then
+    ACTIVE_REMOTE=$(cat "$ACTIVE_FILE")
+    if [[ -f "$REMOTES_DIR/$ACTIVE_REMOTE" ]]; then
+        HAS_REMOTE=true
+    fi
+fi
+
+# Determine remote restore script path
+REMOTE_RESTORE_SCRIPT="${INSTALL_DIR:-}/plugins/remote-save/remote-restore-full.sh"
+
+# If no local state exists
 if [[ ! -f "$STATE_FILE" ]]; then
+    if [[ "$HAS_REMOTE" == true && -x "$REMOTE_RESTORE_SCRIPT" ]]; then
+        # No local state but remote configured - offer remote restore
+        tmux display-menu -T "Para-LLM: No local state. Remote '$ACTIVE_REMOTE' available." \
+            "Pull & Restore from remote"  "r" "run-shell -b '$REMOTE_RESTORE_SCRIPT'" \
+            "Skip"                        "s" ""
+    fi
     exit 0
 fi
 
 # Parse state file
 TIMESTAMP=$(grep "^# saved:" "$STATE_FILE" | sed 's/^# saved: //')
-SESSION_COUNT=$(grep -v "^#" "$STATE_FILE" | grep -v "^window_name" | grep "|true$" | wc -l | tr -d ' ')
+SESSION_COUNT=$(grep -v "^#" "$STATE_FILE" | grep -v "^window_name" | grep "|true|" | wc -l | tr -d ' ')
 
 if [[ "$SESSION_COUNT" -eq 0 ]]; then
     exit 0
@@ -48,8 +73,16 @@ fi
 DISPLAY_TIME="${AGE_DISPLAY:-$TIMESTAMP}"
 TITLE="Para-LLM Recovery: $SESSION_COUNT session(s) from $DISPLAY_TIME${AGE_WARNING:-}"
 
-# Use tmux display-menu for the prompt
-tmux display-menu -T "$TITLE" \
-    "Restore"  "r" "run-shell -b '$PARA_LLM_ROOT/scripts/para-llm-do-restore.sh'" \
-    "Discard"  "d" "run-shell -b '$PARA_LLM_ROOT/scripts/para-llm-do-discard.sh'" \
-    "Skip"     "s" ""
+# Build menu with optional remote restore
+if [[ "$HAS_REMOTE" == true && -x "$REMOTE_RESTORE_SCRIPT" ]]; then
+    tmux display-menu -T "$TITLE" \
+        "Restore (local)"   "r" "run-shell -b '$PARA_LLM_ROOT/scripts/para-llm-do-restore.sh'" \
+        "Restore (remote)"  "R" "run-shell -b '$REMOTE_RESTORE_SCRIPT'" \
+        "Discard"           "d" "run-shell -b '$PARA_LLM_ROOT/scripts/para-llm-do-discard.sh'" \
+        "Skip"              "s" ""
+else
+    tmux display-menu -T "$TITLE" \
+        "Restore"  "r" "run-shell -b '$PARA_LLM_ROOT/scripts/para-llm-do-restore.sh'" \
+        "Discard"  "d" "run-shell -b '$PARA_LLM_ROOT/scripts/para-llm-do-discard.sh'" \
+        "Skip"     "s" ""
+fi

--- a/scripts/para-llm-restore.sh
+++ b/scripts/para-llm-restore.sh
@@ -28,7 +28,7 @@ fi
 
 # Read saved state entries (skip comments and header)
 declare -A SAVED_ENTRIES
-while IFS='|' read -r win_name pane_path project branch had_claude; do
+while IFS='|' read -r win_name pane_path project branch had_claude git_remote; do
     # Skip comments and header
     [[ "$win_name" =~ ^# ]] && continue
     [[ "$win_name" == "window_name" ]] && continue


### PR DESCRIPTION
## Summary
- Add plugin to periodically push workspace state (session-state + config, ~1KB) to a remote storage backend so it can be restored on a fresh instance
- Repos are not saved remotely — they are re-cloned from git remote URLs on restore (new `git_remote` column in session-state format)
- SSH/rsync backend with support for `~/.ssh/config` hosts and reverse tunnels (`ssh -R`)
- fzf-based remote management menu (`Ctrl+b t`) with step-based navigation and Escape-to-go-back
- Recovery prompt offers remote restore when no local state exists

## Test plan
- [ ] Run `./install.sh -y`, verify `remotes/` dir created and `REMOTE_SAVE_ENABLED=1` in config
- [ ] `Ctrl+b t` > Add remote via SSH config host, verify file in `$PARA_LLM_ROOT/remotes/`
- [ ] `Ctrl+b t` > Add remote via reverse tunnel (SSH in with `-R 2222:localhost:22`)
- [ ] Test connection from remote management menu
- [ ] Wait 1 minute for save cycle, verify `git_remote` column in session-state file
- [ ] On fresh instance: install, recovery prompt offers "Pull & Restore from remote"
- [ ] Verify Escape key goes back at every text input prompt
- [ ] Verify existing local restore still works with new 6-column state format

🤖 Generated with [Claude Code](https://claude.com/claude-code)