### PR TITLE
Add NVIDIA OpenShell sandbox integration plugin

### DIFF
--- a/.llm-context/topics/architectural-decisions.md
+++ b/.llm-context/topics/architectural-decisions.md
@@ -272,3 +272,25 @@ $PARA_LLM_ROOT/remotes/
 ```
 
 **File**: `plugins/remote-save/`
+
+---
+
+## ADR-009: OpenShell Sandbox Integration via MCP Tool Bridge
+
+**Decision**: Use an MCP server to bridge Claude's intelligence (auth error detection) with secure secret registration (tmux popup with `read -s`).
+
+**Context**: Running Claude Code in OpenShell sandboxes requires secrets (API keys, tokens) to be injected. Secret values must never flow through the LLM conversation, but the LLM is best positioned to detect when secrets are needed (parsing auth errors, knowing service-to-secret mappings).
+
+**Rationale**:
+- MCP tools are the standard way to give Claude Code custom callable tools
+- Claude handles detection and mapping (high intelligence required)
+- The MCP server spawns a tmux popup for the actual value entry (secure, non-LLM)
+- Three scope levels (task/project/global) give users control over secret persistence
+- Graceful degradation: if OpenShell is disabled or fails, standard host execution continues
+
+**Trade-offs**:
+- Requires MCP server process running alongside Claude
+- Bash-based MCP server is simpler but less robust than a Python/Node implementation
+- Tmux popup requires active tmux session (won't work in headless mode)
+
+**File**: `plugins/openshell/mcp-secret-server/`, `plugins/openshell/openshell-sandbox.sh`

--- a/.llm-context/topics/product-features.md
+++ b/.llm-context/topics/product-features.md
@@ -296,3 +296,32 @@ plugins/remote-save/
     └── ProjectName-feature/
         └── ProjectName/      # Cloned repo
 ```
+
+---
+
+### 8. OpenShell Sandbox Integration (`Ctrl+b o`)
+Optional plugin that runs Claude Code environments inside NVIDIA OpenShell sandboxes for kernel-level security isolation (Landlock, seccomp, network policies).
+
+**Sandbox creation** (integrated into `Ctrl+b c`):
+- When `OPENSHELL_ENABLED=1`, users are prompted "Run in: Host / OpenShell Sandbox" during environment creation
+- If `OPENSHELL_AUTO_SANDBOX=1`, all new environments are sandboxed automatically
+- Sandbox lifecycle is transparent: resume reconnects, cleanup destroys
+
+**Management menu** (`Ctrl+b o`):
+- List/connect/destroy sandboxes
+- View sandbox logs
+- Manage secrets (interactive `read -s`, no LLM involvement)
+- Update policies on running sandboxes
+- Gateway status
+
+**MCP Secret Registration**:
+- Claude can call `register_secret` tool when it encounters auth errors
+- Triggers a tmux popup for secure secret entry (value never touches LLM)
+- Users choose scope: this task only / this project / all projects (global)
+
+**Policy system**:
+- Resolution chain: project repo → user per-project → user default → shipped default
+- Policies control filesystem, network, and process access
+- Network policies ensure secrets can only reach intended endpoints
+
+**File**: `plugins/openshell/`

--- a/envs.sh
+++ b/envs.sh
@@ -61,7 +61,18 @@ for d in "$ENVS_DIR"/*/; do
     [[ "$unpushed" -gt 0 ]] && status+="↑${unpushed} unpushed "
     [[ -z "$status" ]] && status="clean"
 
-    printf "%-40s %-25s %s\n" "$env_name" "$branch" "$status"
+    # Check if environment is running in an OpenShell sandbox
+    local sandbox_indicator=""
+    if [[ -d "$PARA_LLM_ROOT/openshell/state/sandboxes" ]]; then
+        local project_name="${env_name%%-*}"
+        local branch_name="${env_name#*-}"
+        local sandbox_name="para-$(echo "${project_name}-${branch_name}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g')"
+        if [[ -f "$PARA_LLM_ROOT/openshell/state/sandboxes/$sandbox_name" ]]; then
+            sandbox_indicator=" [sandboxed]"
+        fi
+    fi
+
+    printf "%-40s %-25s %s\n" "$env_name" "$branch" "${status}${sandbox_indicator}"
 
     if $VERBOSE && [[ "$unpushed" -gt 0 ]]; then
         git -C "$dir" log --oneline @{u}.. 2>/dev/null | sed 's/^/    /'

--- a/install.sh
+++ b/install.sh
@@ -244,11 +244,16 @@ if [[ "$OPENSHELL_ENABLED_INSTALL" == true ]]; then
     # Create OpenShell directories
     mkdir -p "$PARA_LLM_ROOT/openshell/state/sandboxes"
     mkdir -p "$PARA_LLM_ROOT/openshell/policies"
-    mkdir -p "$PARA_LLM_ROOT/openshell/secrets"
 
-    # Create global secrets file with restricted permissions
-    touch "$PARA_LLM_ROOT/openshell/.secrets"
-    chmod 600 "$PARA_LLM_ROOT/openshell/.secrets"
+    # Check for OS keychain availability
+    if [[ "$(uname)" == "Darwin" ]] && command -v security &>/dev/null; then
+        echo "  Keychain: macOS Keychain (secrets stored securely)"
+    elif command -v secret-tool &>/dev/null; then
+        echo "  Keychain: Linux Secret Service (secrets stored securely)"
+    else
+        echo "  Warning: No OS keychain found (macOS security / Linux secret-tool)"
+        echo "  Secrets will not be stored persistently. Install secret-tool or use macOS."
+    fi
 
     # Copy default policy templates
     if [[ -d "$SCRIPT_DIR/plugins/openshell/policies" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -200,6 +200,80 @@ cat >> "$PARA_LLM_ROOT/config" << 'EOF'
 REMOTE_SAVE_ENABLED=1
 EOF
 
+# --- Optional: OpenShell sandbox plugin ---
+OPENSHELL_ENABLED_INSTALL=false
+if [[ "$NON_INTERACTIVE" == true ]]; then
+    echo "Skipping OpenShell plugin (non-interactive mode)"
+else
+    echo ""
+    echo "Optional: OpenShell sandbox isolation plugin"
+    echo "  Runs Claude Code environments inside NVIDIA OpenShell sandboxes"
+    echo "  Provides kernel-level isolation via Docker + Landlock + seccomp"
+    echo ""
+    echo "  Requirements:"
+    echo "    openshell CLI  (install via: uv tool install -U openshell)"
+    echo "    Docker         (must be running)"
+    echo ""
+    read -r -p "Install OpenShell plugin? [y/N]: " openshell_choice
+    if [[ "$openshell_choice" =~ ^[Yy] ]]; then
+        OPENSHELL_ENABLED_INSTALL=true
+    fi
+fi
+
+if [[ "$OPENSHELL_ENABLED_INSTALL" == true ]]; then
+    echo ""
+    echo "Setting up OpenShell plugin..."
+
+    # Check for openshell CLI
+    if ! command -v openshell &>/dev/null; then
+        echo "  Warning: openshell CLI not found on PATH"
+        echo "  Install with: uv tool install -U openshell"
+    else
+        echo "  openshell CLI found"
+    fi
+
+    # Check for Docker
+    if ! command -v docker &>/dev/null; then
+        echo "  Warning: Docker not found on PATH"
+    elif ! docker info &>/dev/null 2>&1; then
+        echo "  Warning: Docker is not running"
+    else
+        echo "  Docker is running"
+    fi
+
+    # Create OpenShell directories
+    mkdir -p "$PARA_LLM_ROOT/openshell/state/sandboxes"
+    mkdir -p "$PARA_LLM_ROOT/openshell/policies"
+    mkdir -p "$PARA_LLM_ROOT/openshell/secrets"
+
+    # Create global secrets file with restricted permissions
+    touch "$PARA_LLM_ROOT/openshell/.secrets"
+    chmod 600 "$PARA_LLM_ROOT/openshell/.secrets"
+
+    # Copy default policy templates
+    if [[ -d "$SCRIPT_DIR/plugins/openshell/policies" ]]; then
+        cp "$SCRIPT_DIR/plugins/openshell/policies/"*.yaml "$PARA_LLM_ROOT/openshell/policies/" 2>/dev/null || true
+        echo "  Installed default policy templates"
+    fi
+
+    # Save OpenShell config
+    cat >> "$PARA_LLM_ROOT/config" << 'EOF'
+
+# OpenShell sandbox settings
+OPENSHELL_ENABLED=1
+OPENSHELL_AUTO_SANDBOX=0
+OPENSHELL_SYNC_STRATEGY="git"
+OPENSHELL_DEFAULT_POLICY=""
+EOF
+    echo "  OpenShell plugin enabled (Ctrl+b o)"
+else
+    cat >> "$PARA_LLM_ROOT/config" << 'EOF'
+
+# OpenShell sandbox settings (disabled - re-run install.sh to enable)
+OPENSHELL_ENABLED=0
+EOF
+fi
+
 echo "Configuration saved:"
 echo "  Bootstrap pointer: $BOOTSTRAP_FILE"
 echo "  Config: $PARA_LLM_ROOT/config"
@@ -232,6 +306,11 @@ fi
 if [[ -d "$SCRIPT_DIR/plugins/remote-save" ]]; then
     chmod +x "$SCRIPT_DIR/plugins/remote-save/"*.sh 2>/dev/null || true
     chmod +x "$SCRIPT_DIR/plugins/remote-save/backends/"*.sh 2>/dev/null || true
+fi
+if [[ -d "$SCRIPT_DIR/plugins/openshell" ]]; then
+    chmod +x "$SCRIPT_DIR/plugins/openshell/"*.sh 2>/dev/null || true
+    chmod +x "$SCRIPT_DIR/plugins/openshell/para-llm-secrets" 2>/dev/null || true
+    chmod +x "$SCRIPT_DIR/plugins/openshell/mcp-secret-server/"*.sh 2>/dev/null || true
 fi
 
 # Make recovery scripts executable
@@ -320,6 +399,32 @@ if [[ -f "$HOOKS_CONFIG" ]]; then
     fi
 fi
 
+# Register MCP secret server if OpenShell is enabled
+if [[ "$OPENSHELL_ENABLED_INSTALL" == true ]]; then
+    echo ""
+    echo "Registering MCP secret server for OpenShell..."
+    MCP_SERVER_PATH="$SCRIPT_DIR/plugins/openshell/mcp-secret-server/server.sh"
+
+    if [[ -f "$CLAUDE_SETTINGS" ]] && command -v jq &>/dev/null; then
+        # Add mcpServers entry
+        MCP_CONFIG=$(cat <<MCPEOF
+{
+    "command": "$MCP_SERVER_PATH",
+    "args": ["--para-llm-root", "$PARA_LLM_ROOT"]
+}
+MCPEOF
+)
+        jq --argjson mcp "$MCP_CONFIG" '.mcpServers = (.mcpServers // {}) + {"para-llm-secrets": $mcp}' \
+            "$CLAUDE_SETTINGS" > "$CLAUDE_SETTINGS.tmp" && \
+            mv "$CLAUDE_SETTINGS.tmp" "$CLAUDE_SETTINGS"
+        echo "  Registered para-llm-secrets MCP server in $CLAUDE_SETTINGS"
+    else
+        echo "  Warning: Cannot register MCP server (jq not found or no settings file)"
+        echo "  Manually add to $CLAUDE_SETTINGS:"
+        echo "    \"mcpServers\": {\"para-llm-secrets\": {\"command\": \"$MCP_SERVER_PATH\"}}"
+    fi
+fi
+
 # Backup existing tmux.conf if it exists
 echo ""
 if [[ -f ~/.tmux.conf ]]; then
@@ -375,6 +480,15 @@ bind-key t display-popup -E -w 60% -h 60% "$SCRIPT_DIR/plugins/remote-save/remot
 
 EOF
 
+# Conditionally add OpenShell binding
+if [[ "$OPENSHELL_ENABLED_INSTALL" == true ]]; then
+cat >> ~/.tmux.conf << EOF
+
+# Ctrl+b o: OpenShell sandbox management menu
+bind-key o display-popup -E -w 60% -h 60% "$SCRIPT_DIR/plugins/openshell/openshell-manage.sh"
+EOF
+fi
+
 # Conditionally add STT binding
 if [[ "$STT_ENABLED" == true ]]; then
 cat >> ~/.tmux.conf << EOF
@@ -410,6 +524,13 @@ EOF
 if [[ "$STT_ENABLED" == true ]]; then
 cat >> ~/.tmux.conf << EOF
 set -ga status-right ' #($SCRIPT_DIR/plugins/stt/stt-status.sh)'
+EOF
+fi
+
+# Conditionally add OpenShell status
+if [[ "$OPENSHELL_ENABLED_INSTALL" == true ]]; then
+cat >> ~/.tmux.conf << EOF
+set -ga status-right ' #($SCRIPT_DIR/plugins/openshell/openshell-status.sh)'
 EOF
 fi
 
@@ -457,6 +578,9 @@ echo "  Ctrl+b t  - Remote management (add/test/toggle remotes)"
 echo "  Ctrl+b r  - Manual restore Claude sessions"
 if [[ "$STT_ENABLED" == true ]]; then
 echo "  Ctrl+b a  - Toggle speech-to-text recording"
+fi
+if [[ "$OPENSHELL_ENABLED_INSTALL" == true ]]; then
+echo "  Ctrl+b o  - OpenShell sandbox management"
 fi
 echo ""
 echo "Recovery:"

--- a/install.sh
+++ b/install.sh
@@ -244,15 +244,17 @@ if [[ "$OPENSHELL_ENABLED_INSTALL" == true ]]; then
     # Create OpenShell directories
     mkdir -p "$PARA_LLM_ROOT/openshell/state/sandboxes"
     mkdir -p "$PARA_LLM_ROOT/openshell/policies"
+    mkdir -p "$PARA_LLM_ROOT/openshell/secrets"
+    chmod 700 "$PARA_LLM_ROOT/openshell/secrets"
 
     # Check for OS keychain availability
     if [[ "$(uname)" == "Darwin" ]] && command -v security &>/dev/null; then
-        echo "  Keychain: macOS Keychain (secrets stored securely)"
+        echo "  Secrets: macOS Keychain (encrypted at rest)"
     elif command -v secret-tool &>/dev/null; then
-        echo "  Keychain: Linux Secret Service (secrets stored securely)"
+        echo "  Secrets: Linux Secret Service (encrypted at rest)"
     else
-        echo "  Warning: No OS keychain found (macOS security / Linux secret-tool)"
-        echo "  Secrets will not be stored persistently. Install secret-tool or use macOS."
+        echo "  Secrets: file-based fallback (chmod 600 in $PARA_LLM_ROOT/openshell/secrets/)"
+        echo "  For encrypted storage, install libsecret (secret-tool) or use macOS"
     fi
 
     # Copy default policy templates

--- a/install.sh
+++ b/install.sh
@@ -461,9 +461,10 @@ cat >> ~/.tmux.conf << EOF
 
 # para-llm-directory bindings
 
-# Enable extended keys so Shift+Enter passes through to Claude Code as newline
+# Enable extended keys and passthrough so Shift+Enter works in Claude Code
 set -s extended-keys on
 set -as terminal-features 'xterm*:extkeys'
+set -g allow-passthrough on
 
 # Enable mouse/trackpad scrolling and pane selection
 set -g mouse on

--- a/plugins/claude-state-monitor/state-detector.sh
+++ b/plugins/claude-state-monitor/state-detector.sh
@@ -173,7 +173,16 @@ write_display() {
         *)       label="$LABEL_WORKING" ;;
     esac
 
-    local display="#[fg=$color]$label | $PROJECT | $BRANCH#[default]"
+    # Check if this environment is running in an OpenShell sandbox
+    local sandbox_indicator=""
+    if [[ -n "${PARA_LLM_ROOT:-}" && -d "$PARA_LLM_ROOT/openshell/state/sandboxes" ]]; then
+        local sandbox_name="para-$(echo "${PROJECT}-${BRANCH}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g')"
+        if [[ -f "$PARA_LLM_ROOT/openshell/state/sandboxes/$sandbox_name" ]]; then
+            sandbox_indicator=" | #[fg=cyan]sandbox#[default]"
+        fi
+    fi
+
+    local display="#[fg=$color]$label | $PROJECT | $BRANCH${sandbox_indicator}#[default]"
     tmux set-option -p -t "$PANE_ID" @pane_display "$display" 2>/dev/null || true
 }
 

--- a/plugins/openshell/mcp-secret-server/popup-interactive.sh
+++ b/plugins/openshell/mcp-secret-server/popup-interactive.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# popup-interactive.sh - Tmux popup for running interactive commands
+# Launched by the MCP server when Claude calls run_interactive
+# Runs a command in a full interactive shell, captures exit code.
+#
+# Arguments:
+#   $1 - Command to run
+#   $2 - Reason (displayed to user)
+#   $3 - Result file path (where to write the outcome)
+
+set -u
+
+# Source user profile for PATH
+if [[ -f "$HOME/.bashrc" ]]; then
+    source "$HOME/.bashrc" 2>/dev/null || true
+elif [[ -f "$HOME/.bash_profile" ]]; then
+    source "$HOME/.bash_profile" 2>/dev/null || true
+elif [[ -f "$HOME/.profile" ]]; then
+    source "$HOME/.profile" 2>/dev/null || true
+fi
+
+COMMAND="${1:-}"
+REASON="${2:-}"
+RESULT_FILE="${3:-}"
+
+if [[ -z "$COMMAND" || -z "$RESULT_FILE" ]]; then
+    echo "Usage: popup-interactive.sh <command> <reason> <result-file>"
+    exit 1
+fi
+
+echo ""
+echo "Interactive Session"
+echo "==================="
+echo ""
+if [[ -n "$REASON" ]]; then
+    echo "  $REASON"
+    echo ""
+fi
+echo "  Running: $COMMAND"
+echo "  (Complete the interactive flow, then this window will close)"
+echo ""
+echo "---"
+echo ""
+
+# Run the command in an interactive subshell
+eval "$COMMAND"
+exit_code=$?
+
+echo ""
+echo "---"
+
+if [[ $exit_code -eq 0 ]]; then
+    echo "  Command completed successfully."
+    cat > "$RESULT_FILE" << EOF
+{"success":true,"exit_code":0,"message":"Interactive command completed successfully"}
+EOF
+else
+    echo "  Command exited with code $exit_code."
+    cat > "$RESULT_FILE" << EOF
+{"success":false,"exit_code":$exit_code,"message":"Interactive command exited with code $exit_code"}
+EOF
+fi
+
+echo ""
+read -r -p "  Press Enter to close..."

--- a/plugins/openshell/mcp-secret-server/popup-register.sh
+++ b/plugins/openshell/mcp-secret-server/popup-register.sh
@@ -58,10 +58,27 @@ if secret_exists "$SECRET_NAME" "$PROJECT" "$SANDBOX_STATE"; then
     fi
 fi
 
-# Read the secret value (silent input)
+# Read the secret value (masked input - shows * per character)
 printf "  Value: "
-IFS= read -r -s secret_value
-echo ""
+secret_value=""
+while true; do
+    IFS= read -r -s -n 1 ch
+    # Enter key
+    if [[ "$ch" == "" ]]; then
+        echo ""
+        break
+    fi
+    # Backspace (ASCII 127 or 8)
+    if [[ "$ch" == $'\177' || "$ch" == $'\b' ]]; then
+        if [[ -n "$secret_value" ]]; then
+            secret_value="${secret_value%?}"
+            printf '\b \b'
+        fi
+        continue
+    fi
+    secret_value+="$ch"
+    printf '*'
+done
 
 if [[ -z "$secret_value" ]]; then
     echo ""

--- a/plugins/openshell/mcp-secret-server/popup-register.sh
+++ b/plugins/openshell/mcp-secret-server/popup-register.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# popup-register.sh - Tmux popup for secret registration
+# Launched by the MCP server when Claude calls register_secret
+# Handles: display reason, read -s for value, fzf for scope selection
+#
+# Arguments:
+#   $1 - Secret name (e.g., GITHUB_TOKEN)
+#   $2 - Reason (e.g., "gh CLI needs GitHub authentication")
+#   $3 - Project name (for project-scoped storage)
+#   $4 - Sandbox state file path (for task-scoped storage)
+#   $5 - Result file path (where to write the outcome)
+
+set -u
+
+# Source user profile for PATH (fzf may be in ~/.fzf/bin)
+if [[ -f "$HOME/.bashrc" ]]; then
+    source "$HOME/.bashrc" 2>/dev/null || true
+elif [[ -f "$HOME/.bash_profile" ]]; then
+    source "$HOME/.bash_profile" 2>/dev/null || true
+elif [[ -f "$HOME/.profile" ]]; then
+    source "$HOME/.profile" 2>/dev/null || true
+fi
+
+SECRET_NAME="${1:-}"
+REASON="${2:-}"
+PROJECT="${3:-}"
+SANDBOX_STATE="${4:-}"
+RESULT_FILE="${5:-}"
+
+if [[ -z "$SECRET_NAME" || -z "$RESULT_FILE" ]]; then
+    echo "Usage: popup-register.sh <name> <reason> <project> <sandbox-state> <result-file>"
+    exit 1
+fi
+
+# Source secrets helpers
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_DIR="$(dirname "$SCRIPT_DIR")"
+source "$PLUGIN_DIR/openshell-secrets.sh"
+
+echo ""
+echo "Secret Registration"
+echo "==================="
+echo ""
+echo "  Claude needs: $SECRET_NAME"
+if [[ -n "$REASON" ]]; then
+    echo "  Reason: $REASON"
+fi
+echo ""
+
+# Check if already registered
+if secret_exists "$SECRET_NAME" "$PROJECT" "$SANDBOX_STATE"; then
+    echo "  This secret is already registered."
+    echo "  Overwrite? [y/N]: "
+    read -r confirm
+    if [[ ! "$confirm" =~ ^[Yy] ]]; then
+        echo '{"success":true,"message":"Secret already registered"}' > "$RESULT_FILE"
+        exit 0
+    fi
+fi
+
+# Read the secret value (silent input)
+printf "  Value: "
+IFS= read -r -s secret_value
+echo ""
+
+if [[ -z "$secret_value" ]]; then
+    echo ""
+    echo "  Cancelled (empty value)."
+    echo '{"success":false,"message":"User cancelled - empty value"}' > "$RESULT_FILE"
+    exit 0
+fi
+
+# Select scope
+echo ""
+SCOPE_OPTIONS="This task only"
+if [[ -n "$PROJECT" ]]; then
+    SCOPE_OPTIONS="${SCOPE_OPTIONS}\nThis project ($PROJECT)"
+fi
+SCOPE_OPTIONS="${SCOPE_OPTIONS}\nAll projects (global)\nCancel"
+
+SELECTED_SCOPE=$(printf "%b" "$SCOPE_OPTIONS" | fzf --prompt="Register for: " --height=8 --no-info)
+
+case "$SELECTED_SCOPE" in
+    "This task only")
+        secret_store "$SECRET_NAME" "$secret_value" "task" "$PROJECT" "$SANDBOX_STATE"
+        SCOPE_DESC="task"
+        ;;
+    "This project"*)
+        secret_store "$SECRET_NAME" "$secret_value" "project" "$PROJECT" "$SANDBOX_STATE"
+        SCOPE_DESC="project"
+        ;;
+    "All projects (global)")
+        secret_store "$SECRET_NAME" "$secret_value" "global" "" ""
+        SCOPE_DESC="global"
+        ;;
+    *)
+        echo ""
+        echo "  Cancelled."
+        echo '{"success":false,"message":"User cancelled scope selection"}' > "$RESULT_FILE"
+        exit 0
+        ;;
+esac
+
+# Clear the secret value from memory
+secret_value=""
+
+echo ""
+echo "  Secret '$SECRET_NAME' registered (scope: $SCOPE_DESC)"
+
+# Write result for MCP server to read
+cat > "$RESULT_FILE" << EOF
+{"success":true,"message":"Secret '$SECRET_NAME' registered with scope '$SCOPE_DESC'","scope":"$SCOPE_DESC"}
+EOF

--- a/plugins/openshell/mcp-secret-server/server.sh
+++ b/plugins/openshell/mcp-secret-server/server.sh
@@ -147,7 +147,7 @@ handle_initialize() {
     send_response "$id" '{
         "protocolVersion": "2024-11-05",
         "capabilities": {"tools": {}},
-        "serverInfo": {"name": "para-llm-secrets", "version": "1.0.0"}
+        "serverInfo": {"name": "para-llm-tools", "version": "1.0.0"}
     }'
 }
 
@@ -193,6 +193,24 @@ handle_tools_list() {
                         }
                     },
                     "required": ["name"]
+                }
+            },
+            {
+                "name": "run_interactive",
+                "description": "Run a command that requires interactive user input in a tmux popup. Use this when a command needs user interaction that cannot go through the LLM (e.g., browser-based OAuth flows, interactive configuration wizards, TUI menus). The user completes the interaction directly in the popup, then control returns to you with the exit code. Examples: rclone config, gh auth login, aws configure, gcloud auth login, ssh-keygen.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "string",
+                            "description": "The shell command to run interactively (e.g., rclone config, gh auth login)"
+                        },
+                        "reason": {
+                            "type": "string",
+                            "description": "A brief explanation shown to the user about why this interactive session is needed"
+                        }
+                    },
+                    "required": ["command", "reason"]
                 }
             }
         ]
@@ -311,6 +329,52 @@ handle_tool_call() {
                 send_response "$id" "{\"content\":[{\"type\":\"text\",\"text\":\"Secret '${check_name}' is registered and available.\"}]}"
             else
                 send_response "$id" "{\"content\":[{\"type\":\"text\",\"text\":\"Secret '${check_name}' is NOT registered. Use register_secret to add it.\"}]}"
+            fi
+            ;;
+
+        run_interactive)
+            local interactive_cmd interactive_reason
+            interactive_cmd=$(json_get "$args_json" "command")
+            interactive_reason=$(json_get "$args_json" "reason")
+
+            if [[ -z "$interactive_cmd" ]]; then
+                send_error "$id" -32602 "Missing required parameter: command"
+                return
+            fi
+
+            # Create a temporary result file
+            local result_file
+            result_file=$(mktemp /tmp/para-llm-interactive-result.XXXXXX)
+
+            local popup_script="$SCRIPT_DIR/popup-interactive.sh"
+
+            if command -v tmux &>/dev/null && [[ -n "${TMUX:-}" ]]; then
+                # Run in tmux popup - use larger size for interactive commands
+                tmux display-popup -E -w 80% -h 80% \
+                    "bash '$popup_script' '$interactive_cmd' '$interactive_reason' '$result_file'"
+
+                # Read the result
+                if [[ -f "$result_file" ]]; then
+                    local result
+                    result=$(cat "$result_file")
+                    rm -f "$result_file"
+
+                    local success
+                    success=$(json_get_any "$result" "success")
+                    local message
+                    message=$(json_get "$result" "message")
+                    local exit_code
+                    exit_code=$(json_get_any "$result" "exit_code")
+                    message=$(json_escape "$message")
+
+                    send_response "$id" "{\"content\":[{\"type\":\"text\",\"text\":\"${message} (exit code: ${exit_code})\"}]}"
+                else
+                    rm -f "$result_file"
+                    send_response "$id" '{"content":[{"type":"text","text":"Interactive session was closed without completing"}]}'
+                fi
+            else
+                rm -f "$result_file"
+                send_error "$id" -32603 "Cannot open interactive popup: no tmux session detected"
             fi
             ;;
 

--- a/plugins/openshell/mcp-secret-server/server.sh
+++ b/plugins/openshell/mcp-secret-server/server.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+# server.sh - MCP server for secret registration
+# Implements JSON-RPC over stdio (MCP protocol)
+# Exposes tools: register_secret, list_secrets, check_secret
+#
+# Usage: server.sh --para-llm-root /path/to/root
+
+set -u
+
+# Parse arguments
+PARA_LLM_ROOT=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --para-llm-root)
+            PARA_LLM_ROOT="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$PARA_LLM_ROOT" ]]; then
+    # Fallback to bootstrap pointer
+    BOOTSTRAP_FILE="$HOME/.para-llm-root"
+    if [[ -f "$BOOTSTRAP_FILE" ]]; then
+        PARA_LLM_ROOT="$(cat "$BOOTSTRAP_FILE")"
+    else
+        PARA_LLM_ROOT="$HOME/.para-llm-directory"
+    fi
+fi
+export PARA_LLM_ROOT
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Source secrets helpers
+source "$PLUGIN_DIR/openshell-secrets.sh"
+
+# Source config for project context
+if [[ -f "$PARA_LLM_ROOT/config" ]]; then
+    source "$PARA_LLM_ROOT/config"
+fi
+
+OPENSHELL_DIR="$PARA_LLM_ROOT/openshell"
+SANDBOX_STATE_DIR="$OPENSHELL_DIR/state/sandboxes"
+
+# --- JSON helpers ---
+
+# Minimal JSON string escaping
+json_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\n'/\\n}"
+    s="${s//$'\t'/\\t}"
+    echo "$s"
+}
+
+# Extract a string value from JSON by key (simple, no nesting)
+json_get() {
+    local json="$1"
+    local key="$2"
+    echo "$json" | sed -n "s/.*\"${key}\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" | head -1
+}
+
+# Extract a value (string or other) from JSON by key
+json_get_any() {
+    local json="$1"
+    local key="$2"
+    # Try string first
+    local val
+    val=$(json_get "$json" "$key")
+    if [[ -n "$val" ]]; then
+        echo "$val"
+        return
+    fi
+    # Try non-string (number, bool, null)
+    echo "$json" | sed -n "s/.*\"${key}\"[[:space:]]*:[[:space:]]*\([^,}]*\).*/\1/p" | head -1 | tr -d ' '
+}
+
+# --- Detect current project/sandbox context ---
+
+# Try to figure out which project/sandbox the current session is for
+# by checking tmux pane CWD against known sandbox state files
+detect_context() {
+    local pane_path=""
+
+    # Try to get current tmux pane's working directory
+    if command -v tmux &>/dev/null && [[ -n "${TMUX:-}" ]]; then
+        pane_path=$(tmux display-message -p '#{pane_current_path}' 2>/dev/null || true)
+    fi
+
+    # Fallback to PWD
+    pane_path="${pane_path:-${PWD:-}}"
+
+    CURRENT_PROJECT=""
+    CURRENT_BRANCH=""
+    CURRENT_SANDBOX_STATE=""
+
+    # Match against sandbox state files
+    if [[ -d "$SANDBOX_STATE_DIR" ]]; then
+        for state_file in "$SANDBOX_STATE_DIR"/*; do
+            [[ -f "$state_file" ]] || continue
+            local env_dir
+            env_dir=$(grep "^ENV_DIR=" "$state_file" 2>/dev/null | cut -d'=' -f2- | tr -d '"')
+            if [[ -n "$env_dir" && "$pane_path" == "$env_dir"* ]]; then
+                CURRENT_PROJECT=$(grep "^PROJECT=" "$state_file" 2>/dev/null | cut -d'=' -f2- | tr -d '"')
+                CURRENT_BRANCH=$(grep "^BRANCH=" "$state_file" 2>/dev/null | cut -d'=' -f2- | tr -d '"')
+                CURRENT_SANDBOX_STATE="$state_file"
+                return
+            fi
+        done
+    fi
+
+    # Try to derive from ENVS_DIR path
+    local envs_dir="${PARA_LLM_ROOT}/envs"
+    if [[ "$pane_path" == "$envs_dir"* ]]; then
+        local rel="${pane_path#$envs_dir/}"
+        local env_name="${rel%%/*}"
+        # env_name format: ProjectName-branch-name
+        CURRENT_PROJECT="${env_name%%-*}"
+        CURRENT_BRANCH="${env_name#*-}"
+    fi
+}
+
+# --- MCP Protocol ---
+
+send_response() {
+    local id="$1"
+    local result="$2"
+    printf '{"jsonrpc":"2.0","id":%s,"result":%s}\n' "$id" "$result"
+}
+
+send_error() {
+    local id="$1"
+    local code="$2"
+    local message="$3"
+    local escaped_msg
+    escaped_msg=$(json_escape "$message")
+    printf '{"jsonrpc":"2.0","id":%s,"error":{"code":%s,"message":"%s"}}\n' "$id" "$code" "$escaped_msg"
+}
+
+handle_initialize() {
+    local id="$1"
+    send_response "$id" '{
+        "protocolVersion": "2024-11-05",
+        "capabilities": {"tools": {}},
+        "serverInfo": {"name": "para-llm-secrets", "version": "1.0.0"}
+    }'
+}
+
+handle_tools_list() {
+    local id="$1"
+    send_response "$id" '{
+        "tools": [
+            {
+                "name": "register_secret",
+                "description": "Register a secret (API key, token, etc.) that is needed for an operation. This opens an interactive popup where the user enters the secret value securely - the value never passes through the LLM. Call this when you encounter authentication errors (401, 403) or when you know a secret is needed before attempting an operation.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "The environment variable name for the secret (e.g., GITHUB_TOKEN, ANTHROPIC_API_KEY, NPM_TOKEN)"
+                        },
+                        "reason": {
+                            "type": "string",
+                            "description": "A brief explanation of why this secret is needed, shown to the user in the registration popup"
+                        }
+                    },
+                    "required": ["name", "reason"]
+                }
+            },
+            {
+                "name": "list_secrets",
+                "description": "List the names of all registered secrets (never returns values). Use this to check what secrets are available before attempting operations that require authentication.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {}
+                }
+            },
+            {
+                "name": "check_secret",
+                "description": "Check if a specific secret is registered. Returns true/false. Use this proactively before attempting authenticated operations.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "The secret name to check (e.g., GITHUB_TOKEN)"
+                        }
+                    },
+                    "required": ["name"]
+                }
+            }
+        ]
+    }'
+}
+
+handle_tool_call() {
+    local id="$1"
+    local json="$2"
+
+    # Extract tool name and arguments
+    local tool_name
+    tool_name=$(json_get "$json" "name")
+    local args_json
+    # Extract the arguments object - everything between "arguments": { and the matching }
+    args_json=$(echo "$json" | sed -n 's/.*"arguments"[[:space:]]*:[[:space:]]*\({[^}]*}\).*/\1/p')
+
+    detect_context
+
+    case "$tool_name" in
+        register_secret)
+            local secret_name reason
+            secret_name=$(json_get "$args_json" "name")
+            reason=$(json_get "$args_json" "reason")
+
+            if [[ -z "$secret_name" ]]; then
+                send_error "$id" -32602 "Missing required parameter: name"
+                return
+            fi
+
+            # Create a temporary result file
+            local result_file
+            result_file=$(mktemp /tmp/para-llm-secret-result.XXXXXX)
+
+            # Launch tmux popup for interactive registration
+            local popup_script="$SCRIPT_DIR/popup-register.sh"
+
+            if command -v tmux &>/dev/null && [[ -n "${TMUX:-}" ]]; then
+                # Run popup in tmux
+                tmux display-popup -E -w 60% -h 50% \
+                    "bash '$popup_script' '$secret_name' '$reason' '$CURRENT_PROJECT' '$CURRENT_SANDBOX_STATE' '$result_file'"
+
+                # Read the result
+                if [[ -f "$result_file" ]]; then
+                    local result
+                    result=$(cat "$result_file")
+                    rm -f "$result_file"
+
+                    local success
+                    success=$(json_get_any "$result" "success")
+                    local message
+                    message=$(json_get "$result" "message")
+                    message=$(json_escape "$message")
+
+                    if [[ "$success" == "true" ]]; then
+                        # If sandbox is running, inject the secret
+                        if [[ -n "$CURRENT_SANDBOX_STATE" ]]; then
+                            local sandbox_name
+                            sandbox_name=$(basename "$CURRENT_SANDBOX_STATE")
+                            local secret_val
+                            secret_val=$(secret_get "$secret_name" "$CURRENT_PROJECT" "$CURRENT_SANDBOX_STATE")
+                            if [[ -n "$secret_val" ]]; then
+                                # Inject into running sandbox
+                                openshell sandbox exec "$sandbox_name" -- sh -c "export ${secret_name}='${secret_val}'" 2>/dev/null || true
+                            fi
+                        fi
+
+                        send_response "$id" "{\"content\":[{\"type\":\"text\",\"text\":\"${message}\"}]}"
+                    else
+                        send_response "$id" "{\"content\":[{\"type\":\"text\",\"text\":\"${message}\"}]}"
+                    fi
+                else
+                    rm -f "$result_file"
+                    send_response "$id" '{"content":[{"type":"text","text":"Secret registration popup was closed without completing"}]}'
+                fi
+            else
+                # No tmux - fall back to direct stdio (less ideal)
+                rm -f "$result_file"
+                send_error "$id" -32603 "Cannot open registration popup: no tmux session detected"
+            fi
+            ;;
+
+        list_secrets)
+            local names
+            names=$(secret_list "$CURRENT_PROJECT" "$CURRENT_SANDBOX_STATE")
+            local names_json="[]"
+            if [[ -n "$names" ]]; then
+                names_json="["
+                local first=true
+                while IFS= read -r name; do
+                    [[ -z "$name" ]] && continue
+                    if [[ "$first" == true ]]; then
+                        first=false
+                    else
+                        names_json+=","
+                    fi
+                    names_json+="\"$(json_escape "$name")\""
+                done <<< "$names"
+                names_json+="]"
+            fi
+
+            send_response "$id" "{\"content\":[{\"type\":\"text\",\"text\":\"Registered secrets: ${names_json}\"}]}"
+            ;;
+
+        check_secret)
+            local check_name
+            check_name=$(json_get "$args_json" "name")
+
+            if [[ -z "$check_name" ]]; then
+                send_error "$id" -32602 "Missing required parameter: name"
+                return
+            fi
+
+            if secret_exists "$check_name" "$CURRENT_PROJECT" "$CURRENT_SANDBOX_STATE"; then
+                send_response "$id" "{\"content\":[{\"type\":\"text\",\"text\":\"Secret '${check_name}' is registered and available.\"}]}"
+            else
+                send_response "$id" "{\"content\":[{\"type\":\"text\",\"text\":\"Secret '${check_name}' is NOT registered. Use register_secret to add it.\"}]}"
+            fi
+            ;;
+
+        *)
+            send_error "$id" -32601 "Unknown tool: $tool_name"
+            ;;
+    esac
+}
+
+# --- Main loop ---
+
+# Read JSON-RPC messages from stdin, one per line
+while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+
+    # Extract method and id
+    local method id
+    method=$(json_get "$line" "method")
+    id=$(json_get_any "$line" "id")
+
+    case "$method" in
+        initialize)
+            handle_initialize "$id"
+            ;;
+        notifications/initialized)
+            # No response needed for notifications
+            ;;
+        tools/list)
+            handle_tools_list "$id"
+            ;;
+        tools/call)
+            handle_tool_call "$id" "$line"
+            ;;
+        *)
+            if [[ -n "$id" ]]; then
+                send_error "$id" -32601 "Method not found: $method"
+            fi
+            ;;
+    esac
+done

--- a/plugins/openshell/mcp-secret-server/server.sh
+++ b/plugins/openshell/mcp-secret-server/server.sh
@@ -277,25 +277,25 @@ handle_tool_call() {
             ;;
 
         list_secrets)
-            local names
-            names=$(secret_list "$CURRENT_PROJECT" "$CURRENT_SANDBOX_STATE")
-            local names_json="[]"
-            if [[ -n "$names" ]]; then
-                names_json="["
+            local entries
+            entries=$(secret_list_with_scope "$CURRENT_PROJECT" "$CURRENT_SANDBOX_STATE")
+            local entries_json="[]"
+            if [[ -n "$entries" ]]; then
+                entries_json="["
                 local first=true
-                while IFS= read -r name; do
+                while IFS=' ' read -r name scope; do
                     [[ -z "$name" ]] && continue
                     if [[ "$first" == true ]]; then
                         first=false
                     else
-                        names_json+=","
+                        entries_json+=","
                     fi
-                    names_json+="\"$(json_escape "$name")\""
-                done <<< "$names"
-                names_json+="]"
+                    entries_json+="{\"name\":\"$(json_escape "$name")\",\"scope\":\"$(json_escape "$scope")\"}"
+                done <<< "$entries"
+                entries_json+="]"
             fi
 
-            send_response "$id" "{\"content\":[{\"type\":\"text\",\"text\":\"Registered secrets: ${names_json}\"}]}"
+            send_response "$id" "{\"content\":[{\"type\":\"text\",\"text\":\"Registered secrets: ${entries_json}\"}]}"
             ;;
 
         check_secret)

--- a/plugins/openshell/mcp-secret-server/server.sh
+++ b/plugins/openshell/mcp-secret-server/server.sh
@@ -203,9 +203,10 @@ handle_tool_call() {
     local id="$1"
     local json="$2"
 
-    # Extract tool name and arguments
+    # Extract tool name - must get params.name, not arguments.name
+    # Use a two-step approach: first extract params object, then get name from it
     local tool_name
-    tool_name=$(json_get "$json" "name")
+    tool_name=$(echo "$json" | sed -n 's/.*"params"[[:space:]]*:[[:space:]]*{[[:space:]]*"name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
     local args_json
     # Extract the arguments object - everything between "arguments": { and the matching }
     args_json=$(echo "$json" | sed -n 's/.*"arguments"[[:space:]]*:[[:space:]]*\({[^}]*}\).*/\1/p')
@@ -326,7 +327,6 @@ while IFS= read -r line; do
     [[ -z "$line" ]] && continue
 
     # Extract method and id
-    local method id
     method=$(json_get "$line" "method")
     id=$(json_get_any "$line" "id")
 

--- a/plugins/openshell/openshell-gateway.sh
+++ b/plugins/openshell/openshell-gateway.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# openshell-gateway.sh - Gateway lifecycle management
+# Ensures the OpenShell gateway is running before sandbox operations
+
+set -u
+
+# Read PARA_LLM_ROOT from bootstrap pointer
+BOOTSTRAP_FILE="$HOME/.para-llm-root"
+if [[ -f "$BOOTSTRAP_FILE" ]]; then
+    PARA_LLM_ROOT="$(cat "$BOOTSTRAP_FILE")"
+fi
+PARA_LLM_ROOT="${PARA_LLM_ROOT:-$HOME/.para-llm-directory}"
+
+OPENSHELL_DIR="$PARA_LLM_ROOT/openshell"
+GATEWAY_STATE="$OPENSHELL_DIR/state/gateway-status"
+
+# Check if openshell CLI is available
+# Returns: 0 if available, 1 if not
+openshell_available() {
+    if ! command -v openshell &>/dev/null; then
+        return 1
+    fi
+    return 0
+}
+
+# Check if Docker is running
+# Returns: 0 if running, 1 if not
+docker_available() {
+    if ! command -v docker &>/dev/null; then
+        return 1
+    fi
+    if ! docker info &>/dev/null 2>&1; then
+        return 1
+    fi
+    return 0
+}
+
+# Check gateway health
+# Returns: 0 if healthy, 1 if not
+gateway_status() {
+    if ! openshell_available; then
+        echo "not-installed"
+        return 1
+    fi
+
+    # Use openshell status to check gateway
+    local status_output
+    if status_output=$(openshell status 2>&1); then
+        echo "running"
+        return 0
+    else
+        echo "stopped"
+        return 1
+    fi
+}
+
+# Ensure the gateway is running, start if needed
+# Returns: 0 if gateway is running (or started), 1 on failure
+# Outputs: status messages to stderr
+ensure_gateway() {
+    if ! openshell_available; then
+        echo "ERROR: openshell CLI not found on PATH" >&2
+        echo "Install with: uv tool install -U openshell" >&2
+        return 1
+    fi
+
+    if ! docker_available; then
+        echo "ERROR: Docker is not running" >&2
+        echo "Start Docker Desktop and try again" >&2
+        return 1
+    fi
+
+    local status
+    status=$(gateway_status)
+    if [[ "$status" == "running" ]]; then
+        return 0
+    fi
+
+    # Gateway not running - openshell sandbox create auto-bootstraps a local gateway
+    # so we don't need to explicitly start it. Just record that we checked.
+    echo "Gateway will be auto-started on first sandbox creation" >&2
+    return 0
+}
+
+# Stop the gateway (for explicit cleanup)
+gateway_stop() {
+    if ! openshell_available; then
+        return 1
+    fi
+    openshell gateway stop 2>&1
+    return $?
+}

--- a/plugins/openshell/openshell-manage.sh
+++ b/plugins/openshell/openshell-manage.sh
@@ -1,0 +1,397 @@
+#!/usr/bin/env bash
+# openshell-manage.sh - fzf-based management menu for OpenShell sandboxes
+# Launched via Ctrl+b o (tmux display-popup)
+
+# Source user profile for PATH (fzf may be installed in ~/.fzf/bin)
+# tmux display-popup runs non-interactive shell, so .bashrc isn't loaded
+# NOTE: set -u must come AFTER sourcing, as bashrc may reference unset variables
+if [[ -f "$HOME/.bashrc" ]]; then
+    source "$HOME/.bashrc" 2>/dev/null || true
+elif [[ -f "$HOME/.bash_profile" ]]; then
+    source "$HOME/.bash_profile" 2>/dev/null || true
+elif [[ -f "$HOME/.profile" ]]; then
+    source "$HOME/.profile" 2>/dev/null || true
+fi
+
+set -u
+
+# Read PARA_LLM_ROOT from bootstrap pointer
+BOOTSTRAP_FILE="$HOME/.para-llm-root"
+if [[ ! -f "$BOOTSTRAP_FILE" ]]; then
+    echo "para-llm: No bootstrap file found"
+    exit 1
+fi
+PARA_LLM_ROOT="$(cat "$BOOTSTRAP_FILE")"
+
+# Source config
+if [[ -f "$PARA_LLM_ROOT/config" ]]; then
+    source "$PARA_LLM_ROOT/config"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/openshell-sandbox.sh"
+source "$SCRIPT_DIR/openshell-secrets.sh"
+
+SANDBOX_STATE_DIR="$PARA_LLM_ROOT/openshell/state/sandboxes"
+mkdir -p "$SANDBOX_STATE_DIR"
+
+# --- Helper ---
+
+# Read a line of input with Escape-to-go-back support
+read_input() {
+    local prompt="$1"
+    local default="${2:-}"
+    REPLY=""
+
+    printf "%s" "$prompt"
+
+    while true; do
+        IFS= read -r -s -n 1 ch
+
+        # Escape key
+        if [[ "$ch" == $'\e' ]]; then
+            read -r -s -n 2 -t 0.1 _ 2>/dev/null || true
+            echo ""
+            return 1
+        fi
+
+        # Enter key
+        if [[ "$ch" == "" ]]; then
+            echo ""
+            if [[ -z "$REPLY" && -n "$default" ]]; then
+                REPLY="$default"
+            fi
+            return 0
+        fi
+
+        # Backspace
+        if [[ "$ch" == $'\177' || "$ch" == $'\b' ]]; then
+            if [[ -n "$REPLY" ]]; then
+                REPLY="${REPLY%?}"
+                printf '\b \b'
+            fi
+            continue
+        fi
+
+        REPLY+="$ch"
+        printf "%s" "$ch"
+    done
+}
+
+# --- Menu actions ---
+
+action_list() {
+    echo ""
+    echo "Active Sandboxes"
+    echo "================"
+
+    local found=false
+    for state_file in "$SANDBOX_STATE_DIR"/*; do
+        [[ -f "$state_file" ]] || continue
+        found=true
+        local name project branch
+        name=$(basename "$state_file")
+        project=$(grep "^PROJECT=" "$state_file" 2>/dev/null | cut -d'=' -f2- | tr -d '"')
+        branch=$(grep "^BRANCH=" "$state_file" 2>/dev/null | cut -d'=' -f2- | tr -d '"')
+
+        local status="unknown"
+        if openshell_available && openshell sandbox get "$name" &>/dev/null 2>&1; then
+            status="running"
+        else
+            status="stopped"
+        fi
+
+        echo "  $name ($project/$branch) [$status]"
+    done
+
+    if [[ "$found" == false ]]; then
+        echo "  No active sandboxes."
+    fi
+    echo ""
+    read -r -p "Press Enter to continue..."
+}
+
+action_connect() {
+    local sandboxes=()
+    for state_file in "$SANDBOX_STATE_DIR"/*; do
+        [[ -f "$state_file" ]] || continue
+        local name project branch
+        name=$(basename "$state_file")
+        project=$(grep "^PROJECT=" "$state_file" 2>/dev/null | cut -d'=' -f2- | tr -d '"')
+        branch=$(grep "^BRANCH=" "$state_file" 2>/dev/null | cut -d'=' -f2- | tr -d '"')
+        sandboxes+=("$name ($project/$branch)")
+    done
+
+    if [[ ${#sandboxes[@]} -eq 0 ]]; then
+        echo "No active sandboxes."
+        read -r -p "Press Enter to continue..."
+        return
+    fi
+
+    echo ""
+    local selected
+    selected=$(printf "%s\n← Back" "${sandboxes[@]}" | fzf --prompt="Connect to: " --height=10 --no-info)
+    [[ -z "$selected" || "$selected" == "← Back" ]] && return
+
+    local name="${selected%% *}"
+    openshell sandbox connect "$name"
+}
+
+action_destroy() {
+    local sandboxes=()
+    for state_file in "$SANDBOX_STATE_DIR"/*; do
+        [[ -f "$state_file" ]] || continue
+        local name project branch
+        name=$(basename "$state_file")
+        project=$(grep "^PROJECT=" "$state_file" 2>/dev/null | cut -d'=' -f2- | tr -d '"')
+        branch=$(grep "^BRANCH=" "$state_file" 2>/dev/null | cut -d'=' -f2- | tr -d '"')
+        sandboxes+=("$name ($project/$branch)")
+    done
+
+    if [[ ${#sandboxes[@]} -eq 0 ]]; then
+        echo "No active sandboxes."
+        read -r -p "Press Enter to continue..."
+        return
+    fi
+
+    echo ""
+    local selected
+    selected=$(printf "%s\n← Back" "${sandboxes[@]}" | fzf --prompt="Destroy sandbox: " --height=10 --no-info)
+    [[ -z "$selected" || "$selected" == "← Back" ]] && return
+
+    local name="${selected%% *}"
+
+    read -r -p "Destroy sandbox '$name'? [y/N]: " confirm
+    if [[ "$confirm" =~ ^[Yy] ]]; then
+        local state_file="$SANDBOX_STATE_DIR/$name"
+        local project branch
+        project=$(grep "^PROJECT=" "$state_file" 2>/dev/null | cut -d'=' -f2- | tr -d '"')
+        branch=$(grep "^BRANCH=" "$state_file" 2>/dev/null | cut -d'=' -f2- | tr -d '"')
+        sandbox_destroy "$project" "$branch"
+        echo "Sandbox '$name' destroyed."
+    fi
+}
+
+action_logs() {
+    local sandboxes=()
+    for state_file in "$SANDBOX_STATE_DIR"/*; do
+        [[ -f "$state_file" ]] || continue
+        local name
+        name=$(basename "$state_file")
+        sandboxes+=("$name")
+    done
+
+    if [[ ${#sandboxes[@]} -eq 0 ]]; then
+        echo "No active sandboxes."
+        read -r -p "Press Enter to continue..."
+        return
+    fi
+
+    echo ""
+    local selected
+    selected=$(printf "%s\n← Back" "${sandboxes[@]}" | fzf --prompt="View logs for: " --height=10 --no-info)
+    [[ -z "$selected" || "$selected" == "← Back" ]] && return
+
+    echo ""
+    echo "Logs for '$selected' (Ctrl+C to stop):"
+    echo ""
+    openshell logs "$selected" --tail --source sandbox 2>&1 || {
+        echo "Failed to retrieve logs."
+    }
+    read -r -p "Press Enter to continue..."
+}
+
+action_manage_secrets() {
+    while true; do
+        echo ""
+        echo "Manage Secrets"
+        echo "=============="
+        local names
+        names=$(secret_list)
+        if [[ -n "$names" ]]; then
+            echo "Registered secrets:"
+            while IFS= read -r name; do
+                [[ -z "$name" ]] && continue
+                echo "  - $name"
+            done <<< "$names"
+        else
+            echo "No secrets registered."
+        fi
+        echo ""
+
+        local action
+        action=$(printf "Add secret\nRemove secret\n← Back" | fzf --prompt="Action: " --height=6 --no-info)
+
+        case "$action" in
+            "Add secret")
+                echo ""
+                read_input "Secret name: " || continue
+                local secret_name="$REPLY"
+                [[ -z "$secret_name" ]] && continue
+
+                printf "Value: "
+                IFS= read -r -s secret_value
+                echo ""
+                [[ -z "$secret_value" ]] && { echo "Cancelled."; continue; }
+
+                local scope
+                scope=$(printf "All projects (global)\n← Back" | fzf --prompt="Scope: " --height=5 --no-info)
+                case "$scope" in
+                    "All projects (global)")
+                        secret_store "$secret_name" "$secret_value" "global"
+                        echo "Secret '$secret_name' registered globally."
+                        ;;
+                    *) continue ;;
+                esac
+                secret_value=""
+                ;;
+            "Remove secret")
+                if [[ -z "$names" ]]; then
+                    echo "Nothing to remove."
+                    continue
+                fi
+                local selected
+                selected=$(printf "%s\n← Back" "$names" | fzf --prompt="Remove: " --height=10 --no-info)
+                [[ -z "$selected" || "$selected" == "← Back" ]] && continue
+                secret_remove "$selected" "global"
+                echo "Secret '$selected' removed."
+                ;;
+            *) return ;;
+        esac
+    done
+}
+
+action_update_policy() {
+    local sandboxes=()
+    for state_file in "$SANDBOX_STATE_DIR"/*; do
+        [[ -f "$state_file" ]] || continue
+        local name
+        name=$(basename "$state_file")
+        sandboxes+=("$name")
+    done
+
+    if [[ ${#sandboxes[@]} -eq 0 ]]; then
+        echo "No active sandboxes."
+        read -r -p "Press Enter to continue..."
+        return
+    fi
+
+    echo ""
+    local selected
+    selected=$(printf "%s\n← Back" "${sandboxes[@]}" | fzf --prompt="Update policy for: " --height=10 --no-info)
+    [[ -z "$selected" || "$selected" == "← Back" ]] && return
+
+    echo ""
+    echo "Current policy can be retrieved with:"
+    echo "  openshell policy get $selected --full"
+    echo ""
+    read_input "Path to new policy YAML: " || return
+    local policy_path="$REPLY"
+
+    if [[ ! -f "$policy_path" ]]; then
+        echo "File not found: $policy_path"
+        return
+    fi
+
+    echo "Updating policy for '$selected'..."
+    openshell policy set "$selected" --policy "$policy_path" --wait 2>&1
+    echo "Done."
+    read -r -p "Press Enter to continue..."
+}
+
+action_gateway_status() {
+    echo ""
+    echo "Gateway Status"
+    echo "=============="
+    if ! openshell_available; then
+        echo "  openshell CLI: NOT INSTALLED"
+        echo "  Install with: uv tool install -U openshell"
+    else
+        echo "  openshell CLI: installed"
+        local status
+        status=$(gateway_status)
+        echo "  Gateway: $status"
+    fi
+
+    if ! docker_available; then
+        echo "  Docker: NOT RUNNING"
+    else
+        echo "  Docker: running"
+    fi
+    echo ""
+    read -r -p "Press Enter to continue..."
+}
+
+action_toggle_auto() {
+    local current="${OPENSHELL_AUTO_SANDBOX:-0}"
+    local new_state
+    if [[ "$current" == "1" ]]; then
+        new_state="0"
+        echo "Auto-sandbox: DISABLED (will ask for each new env)"
+    else
+        new_state="1"
+        echo "Auto-sandbox: ENABLED (all new envs will be sandboxed)"
+    fi
+
+    # Update config file
+    if grep -q "^OPENSHELL_AUTO_SANDBOX=" "$PARA_LLM_ROOT/config" 2>/dev/null; then
+        sed -i.tmp "s/^OPENSHELL_AUTO_SANDBOX=.*/OPENSHELL_AUTO_SANDBOX=$new_state/" "$PARA_LLM_ROOT/config"
+        rm -f "$PARA_LLM_ROOT/config.tmp"
+    else
+        echo "" >> "$PARA_LLM_ROOT/config"
+        echo "OPENSHELL_AUTO_SANDBOX=$new_state" >> "$PARA_LLM_ROOT/config"
+    fi
+}
+
+# --- Main menu ---
+
+while true; do
+    echo ""
+    echo "Para-LLM OpenShell Management"
+    echo "=============================="
+
+    # Count active sandboxes
+    local count=0
+    for f in "$SANDBOX_STATE_DIR"/*; do
+        [[ -f "$f" ]] && (( count++ ))
+    done
+
+    local gw_status="unknown"
+    if openshell_available; then
+        gw_status=$(gateway_status)
+    else
+        gw_status="not installed"
+    fi
+
+    echo "Sandboxes: ${count} active | Gateway: ${gw_status}"
+    echo "Auto-sandbox: ${OPENSHELL_AUTO_SANDBOX:-0}"
+    echo ""
+
+    # Dynamic toggle label
+    local toggle_label
+    if [[ "${OPENSHELL_AUTO_SANDBOX:-0}" == "1" ]]; then
+        toggle_label="Disable auto-sandbox"
+    else
+        toggle_label="Enable auto-sandbox"
+    fi
+
+    ACTION=$(printf "List sandboxes\nConnect to sandbox\nDestroy sandbox\nView sandbox logs\nManage secrets\nUpdate policy\nGateway status\n%s\nExit" "$toggle_label" | \
+        fzf --prompt="Action: " --height=13 --no-info)
+
+    case "$ACTION" in
+        "List sandboxes")       action_list ;;
+        "Connect to sandbox")   action_connect ;;
+        "Destroy sandbox")      action_destroy ;;
+        "View sandbox logs")    action_logs ;;
+        "Manage secrets")       action_manage_secrets ;;
+        "Update policy")        action_update_policy ;;
+        "Gateway status")       action_gateway_status ;;
+        "Enable auto-sandbox"|"Disable auto-sandbox") action_toggle_auto ;;
+        "Exit"|"")              exit 0 ;;
+    esac
+
+    # Re-source config in case toggle changed it
+    if [[ -f "$PARA_LLM_ROOT/config" ]]; then
+        source "$PARA_LLM_ROOT/config"
+    fi
+done

--- a/plugins/openshell/openshell-manage.sh
+++ b/plugins/openshell/openshell-manage.sh
@@ -206,14 +206,14 @@ action_manage_secrets() {
         echo ""
         echo "Manage Secrets"
         echo "=============="
-        local names
-        names=$(secret_list)
-        if [[ -n "$names" ]]; then
+        local entries
+        entries=$(secret_list_with_scope)
+        if [[ -n "$entries" ]]; then
             echo "Registered secrets:"
-            while IFS= read -r name; do
+            while IFS=' ' read -r name scope; do
                 [[ -z "$name" ]] && continue
-                echo "  - $name"
-            done <<< "$names"
+                echo "  - $name ($scope)"
+            done <<< "$entries"
         else
             echo "No secrets registered."
         fi

--- a/plugins/openshell/openshell-manage.sh
+++ b/plugins/openshell/openshell-manage.sh
@@ -230,8 +230,23 @@ action_manage_secrets() {
                 [[ -z "$secret_name" ]] && continue
 
                 printf "Value: "
-                IFS= read -r -s secret_value
-                echo ""
+                secret_value=""
+                while true; do
+                    IFS= read -r -s -n 1 ch
+                    if [[ "$ch" == "" ]]; then
+                        echo ""
+                        break
+                    fi
+                    if [[ "$ch" == $'\177' || "$ch" == $'\b' ]]; then
+                        if [[ -n "$secret_value" ]]; then
+                            secret_value="${secret_value%?}"
+                            printf '\b \b'
+                        fi
+                        continue
+                    fi
+                    secret_value+="$ch"
+                    printf '*'
+                done
                 [[ -z "$secret_value" ]] && { echo "Cancelled."; continue; }
 
                 local scope

--- a/plugins/openshell/openshell-sandbox.sh
+++ b/plugins/openshell/openshell-sandbox.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+# openshell-sandbox.sh - Sandbox lifecycle management
+# Create, connect, destroy, and query OpenShell sandboxes
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source helpers
+source "$SCRIPT_DIR/openshell-gateway.sh"
+source "$SCRIPT_DIR/openshell-secrets.sh"
+
+OPENSHELL_DIR="$PARA_LLM_ROOT/openshell"
+SANDBOX_STATE_DIR="$OPENSHELL_DIR/state/sandboxes"
+
+mkdir -p "$SANDBOX_STATE_DIR"
+
+# --- Naming ---
+
+# Generate a deterministic sandbox name from project and branch
+# Usage: sandbox_name_for_env <project> <branch>
+sandbox_name_for_env() {
+    local project="$1"
+    local branch="$2"
+    # Sanitize: lowercase, replace non-alphanumeric with dash, trim dashes
+    local name="para-${project}-${branch}"
+    name=$(echo "$name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
+    echo "$name"
+}
+
+# --- State tracking ---
+
+# Get the state file path for a sandbox
+_state_file() {
+    local sandbox_name="$1"
+    echo "$SANDBOX_STATE_DIR/$sandbox_name"
+}
+
+# Check if an environment has an associated sandbox
+# Usage: is_env_sandboxed <project> <branch>
+is_env_sandboxed() {
+    local project="$1"
+    local branch="$2"
+    local name
+    name=$(sandbox_name_for_env "$project" "$branch")
+    [[ -f "$(_state_file "$name")" ]]
+}
+
+# Get sandbox name for a given environment directory
+# Usage: get_sandbox_for_env <env-dir>
+get_sandbox_for_env() {
+    local env_dir="$1"
+    for state_file in "$SANDBOX_STATE_DIR"/*; do
+        [[ -f "$state_file" ]] || continue
+        local stored_env_dir
+        stored_env_dir=$(grep "^ENV_DIR=" "$state_file" 2>/dev/null | cut -d'=' -f2- | tr -d '"')
+        if [[ "$stored_env_dir" == "$env_dir" ]]; then
+            basename "$state_file"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# List all tracked sandboxes
+# Outputs: sandbox_name|project|branch|status per line
+list_sandboxed_envs() {
+    for state_file in "$SANDBOX_STATE_DIR"/*; do
+        [[ -f "$state_file" ]] || continue
+        local name project branch
+        name=$(basename "$state_file")
+        # Source the state file to get variables
+        (
+            source "$state_file"
+            local status="unknown"
+            if openshell_available; then
+                if openshell sandbox get "$name" &>/dev/null; then
+                    status="running"
+                else
+                    status="stopped"
+                fi
+            fi
+            echo "${name}|${PROJECT:-}|${BRANCH:-}|${status}"
+        )
+    done
+}
+
+# --- Policy resolution ---
+
+# Resolve which policy file to use for a sandbox
+# Usage: resolve_policy <project> <env-dir>
+# Outputs: path to policy YAML, or empty for default
+resolve_policy() {
+    local project="$1"
+    local env_dir="$2"
+
+    # Source config for OPENSHELL_DEFAULT_POLICY
+    if [[ -f "$PARA_LLM_ROOT/config" ]]; then
+        source "$PARA_LLM_ROOT/config"
+    fi
+
+    # 1. Project-specific policy in repo
+    local repo_policy="$env_dir/.openshell-policy.yaml"
+    if [[ -f "$repo_policy" ]]; then
+        echo "$repo_policy"
+        return 0
+    fi
+
+    # 2. User per-project override
+    local user_project_policy="$OPENSHELL_DIR/policies/${project}.yaml"
+    if [[ -f "$user_project_policy" ]]; then
+        echo "$user_project_policy"
+        return 0
+    fi
+
+    # 3. User global default
+    local user_default="$OPENSHELL_DIR/policies/default.yaml"
+    if [[ -f "$user_default" ]]; then
+        echo "$user_default"
+        return 0
+    fi
+
+    # 4. Config override
+    if [[ -n "${OPENSHELL_DEFAULT_POLICY:-}" && -f "${OPENSHELL_DEFAULT_POLICY}" ]]; then
+        echo "$OPENSHELL_DEFAULT_POLICY"
+        return 0
+    fi
+
+    # 5. Shipped default
+    local shipped_default="$SCRIPT_DIR/policies/default.yaml"
+    if [[ -f "$shipped_default" ]]; then
+        echo "$shipped_default"
+        return 0
+    fi
+
+    # No policy found - let openshell use its built-in default
+    echo ""
+}
+
+# --- Lifecycle ---
+
+# Create a new sandbox for an environment
+# Usage: sandbox_create <project> <branch> <env-dir> <clone-dir>
+# Returns: 0 on success, 1 on failure
+sandbox_create() {
+    local project="$1"
+    local branch="$2"
+    local env_dir="$3"
+    local clone_dir="$4"
+
+    local sandbox_name
+    sandbox_name=$(sandbox_name_for_env "$project" "$branch")
+
+    # Ensure gateway
+    if ! ensure_gateway; then
+        echo "WARN: Cannot start OpenShell gateway, falling back to host execution" >&2
+        return 1
+    fi
+
+    # Resolve policy
+    local policy
+    policy=$(resolve_policy "$project" "$clone_dir")
+    local policy_flag=""
+    if [[ -n "$policy" ]]; then
+        policy_flag="--policy $policy"
+    fi
+
+    # Collect secrets as --env flags
+    local state_file
+    state_file=$(_state_file "$sandbox_name")
+    local env_flags=()
+    while IFS= read -r flag; do
+        [[ -n "$flag" ]] && env_flags+=("$flag")
+    done < <(secret_collect_env_flags "$project" "$state_file")
+
+    # Source config for sync strategy
+    if [[ -f "$PARA_LLM_ROOT/config" ]]; then
+        source "$PARA_LLM_ROOT/config"
+    fi
+    local sync_strategy="${OPENSHELL_SYNC_STRATEGY:-git}"
+
+    # Create the sandbox
+    local create_cmd=(openshell sandbox create --name "$sandbox_name")
+    [[ -n "$policy_flag" ]] && create_cmd+=($policy_flag)
+    create_cmd+=("${env_flags[@]}")
+    create_cmd+=(-- claude --dangerously-skip-permissions)
+
+    echo "Creating OpenShell sandbox '$sandbox_name'..." >&2
+    if ! "${create_cmd[@]}" 2>&1; then
+        echo "ERROR: Failed to create sandbox" >&2
+        return 1
+    fi
+
+    # Sync code
+    if [[ "$sync_strategy" == "upload" ]]; then
+        echo "Uploading code to sandbox..." >&2
+        if ! openshell sandbox upload "$sandbox_name" "$clone_dir" /workspace/ 2>&1; then
+            echo "WARN: Code upload failed" >&2
+        fi
+    fi
+    # For git strategy, the sandbox clones from the remote internally
+
+    # Write state file
+    cat > "$state_file" << STATE_EOF
+# para-llm openshell sandbox state
+SANDBOX_NAME="$sandbox_name"
+ENV_DIR="$env_dir"
+PROJECT="$project"
+BRANCH="$branch"
+CREATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+POLICY_FILE="${policy:-default}"
+SYNC_STRATEGY="$sync_strategy"
+STATE_EOF
+
+    echo "Sandbox '$sandbox_name' created" >&2
+    return 0
+}
+
+# Connect to an existing sandbox
+# Usage: sandbox_connect <project> <branch>
+# Returns: 0 on success, 1 on failure
+sandbox_connect() {
+    local project="$1"
+    local branch="$2"
+
+    local sandbox_name
+    sandbox_name=$(sandbox_name_for_env "$project" "$branch")
+
+    if ! openshell_available; then
+        return 1
+    fi
+
+    # Check if sandbox exists
+    if openshell sandbox get "$sandbox_name" &>/dev/null; then
+        openshell sandbox connect "$sandbox_name"
+        return $?
+    else
+        echo "Sandbox '$sandbox_name' not found" >&2
+        return 1
+    fi
+}
+
+# Destroy a sandbox and clean up state
+# Usage: sandbox_destroy <project> <branch> [clone-dir]
+# Returns: 0 on success, 1 on failure (non-fatal)
+sandbox_destroy() {
+    local project="$1"
+    local branch="$2"
+    local clone_dir="${3:-}"
+
+    local sandbox_name
+    sandbox_name=$(sandbox_name_for_env "$project" "$branch")
+    local state_file
+    state_file=$(_state_file "$sandbox_name")
+
+    # Source state file for sync strategy
+    local sync_strategy="git"
+    if [[ -f "$state_file" ]]; then
+        sync_strategy=$(grep "^SYNC_STRATEGY=" "$state_file" 2>/dev/null | cut -d'=' -f2- | tr -d '"')
+        sync_strategy="${sync_strategy:-git}"
+    fi
+
+    # Sync back uncommitted work if using upload strategy
+    if [[ "$sync_strategy" == "upload" && -n "$clone_dir" ]]; then
+        echo "Syncing changes from sandbox before destruction..." >&2
+        openshell sandbox download "$sandbox_name" /workspace/ "$clone_dir" 2>/dev/null || true
+    fi
+
+    # Delete the sandbox
+    if openshell_available; then
+        echo "Destroying sandbox '$sandbox_name'..." >&2
+        openshell sandbox delete "$sandbox_name" 2>&1 || {
+            echo "WARN: Failed to delete sandbox '$sandbox_name'" >&2
+        }
+    fi
+
+    # Clean up state file and task-scoped secrets
+    rm -f "$state_file"
+    rm -f "$state_file.secrets"
+
+    return 0
+}
+
+# Check if a sandbox exists and is running
+# Usage: sandbox_exists <project> <branch>
+# Returns: 0 if exists and running, 1 otherwise
+sandbox_exists() {
+    local project="$1"
+    local branch="$2"
+
+    local sandbox_name
+    sandbox_name=$(sandbox_name_for_env "$project" "$branch")
+
+    if ! openshell_available; then
+        return 1
+    fi
+
+    openshell sandbox get "$sandbox_name" &>/dev/null
+    return $?
+}
+
+# Get sandbox status string
+# Usage: sandbox_status <project> <branch>
+# Outputs: running | stopped | not-found
+sandbox_status() {
+    local project="$1"
+    local branch="$2"
+
+    local sandbox_name
+    sandbox_name=$(sandbox_name_for_env "$project" "$branch")
+
+    if ! openshell_available; then
+        echo "not-installed"
+        return
+    fi
+
+    if openshell sandbox get "$sandbox_name" &>/dev/null; then
+        echo "running"
+    elif [[ -f "$(_state_file "$sandbox_name")" ]]; then
+        echo "stopped"
+    else
+        echo "not-found"
+    fi
+}

--- a/plugins/openshell/openshell-secrets.sh
+++ b/plugins/openshell/openshell-secrets.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # openshell-secrets.sh - Secret storage helpers for OpenShell plugin
-# Uses OS keychain (macOS Keychain / Linux secret-tool) for persistent secrets.
-# Task-scoped secrets use temporary files (cleaned up on sandbox destroy).
+# Uses OS keychain (macOS Keychain / Linux secret-tool) when available.
+# Falls back to chmod 600 files when no keychain is present.
+# Task-scoped secrets always use temporary files (cleaned up on sandbox destroy).
 # Secret values NEVER flow through the LLM - only through read -s prompts.
 
 set -u
@@ -20,17 +21,102 @@ OPENSHELL_DIR="$PARA_LLM_ROOT/openshell"
 # Keychain service prefix for all para-llm secrets
 _KEYCHAIN_SERVICE="para-llm-openshell"
 
-# --- Keychain backend ---
+# File-based fallback directory (chmod 600 files, used when no keychain available)
+_FILE_SECRETS_DIR="$OPENSHELL_DIR/secrets"
 
-# Detect which keychain backend is available
-# Returns: "macos" | "linux" | "none"
-_detect_keychain() {
+# --- Backend detection ---
+
+# Detect which secret storage backend is available
+# Returns: "macos" | "linux" | "file"
+_detect_backend() {
     if [[ "$(uname)" == "Darwin" ]] && command -v security &>/dev/null; then
         echo "macos"
     elif command -v secret-tool &>/dev/null; then
         echo "linux"
     else
-        echo "none"
+        echo "file"
+    fi
+}
+
+# --- File-based fallback backend ---
+# Used on systems without OS keychain (servers, WSL, minimal distros)
+# Stores secrets in $PARA_LLM_ROOT/openshell/secrets/ with chmod 600
+
+_file_secrets_path() {
+    local scope="$1"
+    local project="${2:-}"
+    case "$scope" in
+        global)  echo "$_FILE_SECRETS_DIR/.global.secrets" ;;
+        project) echo "$_FILE_SECRETS_DIR/${project}.secrets" ;;
+    esac
+}
+
+_file_ensure_dir() {
+    mkdir -p "$_FILE_SECRETS_DIR"
+    chmod 700 "$_FILE_SECRETS_DIR"
+}
+
+_file_store() {
+    local name="$1"
+    local value="$2"
+    local scope="$3"
+    local project="${4:-}"
+    _file_ensure_dir
+    local file
+    file=$(_file_secrets_path "$scope" "$project")
+
+    # Remove existing entry
+    if [[ -f "$file" ]]; then
+        local tmp="${file}.tmp"
+        grep -v "^${name}=" "$file" > "$tmp" 2>/dev/null || true
+        mv "$tmp" "$file"
+    fi
+
+    echo "${name}=${value}" >> "$file"
+    chmod 600 "$file"
+}
+
+_file_get() {
+    local name="$1"
+    local scope="$2"
+    local project="${3:-}"
+    local file
+    file=$(_file_secrets_path "$scope" "$project")
+    if [[ -f "$file" ]]; then
+        grep "^${name}=" "$file" 2>/dev/null | head -1 | cut -d'=' -f2-
+    fi
+}
+
+_file_exists() {
+    local name="$1"
+    local scope="$2"
+    local project="${3:-}"
+    local file
+    file=$(_file_secrets_path "$scope" "$project")
+    [[ -f "$file" ]] && grep -q "^${name}=" "$file" 2>/dev/null
+}
+
+_file_remove() {
+    local name="$1"
+    local scope="$2"
+    local project="${3:-}"
+    local file
+    file=$(_file_secrets_path "$scope" "$project")
+    if [[ -f "$file" ]]; then
+        local tmp="${file}.tmp"
+        grep -v "^${name}=" "$file" > "$tmp" 2>/dev/null || true
+        mv "$tmp" "$file"
+        chmod 600 "$file"
+    fi
+}
+
+_file_list() {
+    local scope="$1"
+    local project="${2:-}"
+    local file
+    file=$(_file_secrets_path "$scope" "$project")
+    if [[ -f "$file" ]]; then
+        grep -v '^#' "$file" 2>/dev/null | grep '=' | cut -d'=' -f1
     fi
 }
 
@@ -56,7 +142,7 @@ _keychain_store() {
     local service
     service=$(_keychain_service_name "$scope" "$project")
     local backend
-    backend=$(_detect_keychain)
+    backend=$(_detect_backend)
 
     case "$backend" in
         macos)
@@ -71,14 +157,14 @@ _keychain_store() {
                 service "$service" account "$name" 2>/dev/null
             return $?
             ;;
-        none)
-            echo "WARN: No keychain available, cannot store secret securely" >&2
-            return 1
+        file)
+            _file_store "$name" "$value" "$scope" "$project"
+            return $?
             ;;
     esac
 }
 
-# Retrieve a secret from the OS keychain
+# Retrieve a secret
 # Usage: _keychain_get <name> <scope> [project]
 # Outputs: the secret value
 _keychain_get() {
@@ -88,7 +174,7 @@ _keychain_get() {
     local service
     service=$(_keychain_service_name "$scope" "$project")
     local backend
-    backend=$(_detect_keychain)
+    backend=$(_detect_backend)
 
     case "$backend" in
         macos)
@@ -99,13 +185,14 @@ _keychain_get() {
             secret-tool lookup service "$service" account "$name" 2>/dev/null
             return $?
             ;;
-        none)
-            return 1
+        file)
+            _file_get "$name" "$scope" "$project"
+            return $?
             ;;
     esac
 }
 
-# Check if a secret exists in the OS keychain
+# Check if a secret exists
 # Usage: _keychain_exists <name> <scope> [project]
 _keychain_exists() {
     local name="$1"
@@ -114,7 +201,7 @@ _keychain_exists() {
     local service
     service=$(_keychain_service_name "$scope" "$project")
     local backend
-    backend=$(_detect_keychain)
+    backend=$(_detect_backend)
 
     case "$backend" in
         macos)
@@ -125,13 +212,14 @@ _keychain_exists() {
             secret-tool lookup service "$service" account "$name" &>/dev/null
             return $?
             ;;
-        none)
-            return 1
+        file)
+            _file_exists "$name" "$scope" "$project"
+            return $?
             ;;
     esac
 }
 
-# Remove a secret from the OS keychain
+# Remove a secret
 # Usage: _keychain_remove <name> <scope> [project]
 _keychain_remove() {
     local name="$1"
@@ -140,7 +228,7 @@ _keychain_remove() {
     local service
     service=$(_keychain_service_name "$scope" "$project")
     local backend
-    backend=$(_detect_keychain)
+    backend=$(_detect_backend)
 
     case "$backend" in
         macos)
@@ -151,8 +239,9 @@ _keychain_remove() {
             secret-tool clear service "$service" account "$name" &>/dev/null
             return $?
             ;;
-        none)
-            return 1
+        file)
+            _file_remove "$name" "$scope" "$project"
+            return $?
             ;;
     esac
 }
@@ -166,7 +255,7 @@ _keychain_list() {
     local service
     service=$(_keychain_service_name "$scope" "$project")
     local backend
-    backend=$(_detect_keychain)
+    backend=$(_detect_backend)
 
     case "$backend" in
         macos)
@@ -196,8 +285,8 @@ _keychain_list() {
                 grep "^attribute.account" | \
                 sed 's/.*= //' | sort -u
             ;;
-        none)
-            return 0
+        file)
+            _file_list "$scope" "$project"
             ;;
     esac
 }

--- a/plugins/openshell/openshell-secrets.sh
+++ b/plugins/openshell/openshell-secrets.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # openshell-secrets.sh - Secret storage helpers for OpenShell plugin
-# Manages .secrets files at global/project/task scopes
-# Secret values NEVER flow through the LLM - only through read -s prompts
+# Uses OS keychain (macOS Keychain / Linux secret-tool) for persistent secrets.
+# Task-scoped secrets use temporary files (cleaned up on sandbox destroy).
+# Secret values NEVER flow through the LLM - only through read -s prompts.
 
 set -u
 
@@ -15,53 +16,224 @@ else
 fi
 
 OPENSHELL_DIR="$PARA_LLM_ROOT/openshell"
-GLOBAL_SECRETS="$OPENSHELL_DIR/.secrets"
-PROJECT_SECRETS_DIR="$OPENSHELL_DIR/secrets"
 
-# Ensure directories and files exist with correct permissions
-_ensure_secrets_dirs() {
-    mkdir -p "$PROJECT_SECRETS_DIR"
-    if [[ ! -f "$GLOBAL_SECRETS" ]]; then
-        touch "$GLOBAL_SECRETS"
-        chmod 600 "$GLOBAL_SECRETS"
+# Keychain service prefix for all para-llm secrets
+_KEYCHAIN_SERVICE="para-llm-openshell"
+
+# --- Keychain backend ---
+
+# Detect which keychain backend is available
+# Returns: "macos" | "linux" | "none"
+_detect_keychain() {
+    if [[ "$(uname)" == "Darwin" ]] && command -v security &>/dev/null; then
+        echo "macos"
+    elif command -v secret-tool &>/dev/null; then
+        echo "linux"
+    else
+        echo "none"
     fi
 }
 
-# Get the path to a project's secrets file
-# Usage: _project_secrets_file <project-name>
-_project_secrets_file() {
-    local project="$1"
-    echo "$PROJECT_SECRETS_DIR/${project}.secrets"
+# Build a keychain service name from scope and project
+# Usage: _keychain_service <scope> [project]
+# Returns: "para-llm-openshell:global" or "para-llm-openshell:project:myproject"
+_keychain_service_name() {
+    local scope="$1"
+    local project="${2:-}"
+    case "$scope" in
+        global)  echo "${_KEYCHAIN_SERVICE}:global" ;;
+        project) echo "${_KEYCHAIN_SERVICE}:project:${project}" ;;
+    esac
 }
 
-# Check if a secret exists in a specific secrets file
-# Usage: _secret_exists_in_file <file> <name>
-# Returns: 0 if found, 1 if not
-_secret_exists_in_file() {
-    local file="$1"
-    local name="$2"
+# Store a secret in the OS keychain
+# Usage: _keychain_store <name> <value> <scope> [project]
+_keychain_store() {
+    local name="$1"
+    local value="$2"
+    local scope="$3"
+    local project="${4:-}"
+    local service
+    service=$(_keychain_service_name "$scope" "$project")
+    local backend
+    backend=$(_detect_keychain)
+
+    case "$backend" in
+        macos)
+            # Delete existing entry first (ignore errors if not found)
+            security delete-generic-password -s "$service" -a "$name" 2>/dev/null || true
+            # Add new entry
+            security add-generic-password -s "$service" -a "$name" -w "$value" 2>/dev/null
+            return $?
+            ;;
+        linux)
+            echo -n "$value" | secret-tool store --label="para-llm: $name ($scope)" \
+                service "$service" account "$name" 2>/dev/null
+            return $?
+            ;;
+        none)
+            echo "WARN: No keychain available, cannot store secret securely" >&2
+            return 1
+            ;;
+    esac
+}
+
+# Retrieve a secret from the OS keychain
+# Usage: _keychain_get <name> <scope> [project]
+# Outputs: the secret value
+_keychain_get() {
+    local name="$1"
+    local scope="$2"
+    local project="${3:-}"
+    local service
+    service=$(_keychain_service_name "$scope" "$project")
+    local backend
+    backend=$(_detect_keychain)
+
+    case "$backend" in
+        macos)
+            security find-generic-password -s "$service" -a "$name" -w 2>/dev/null
+            return $?
+            ;;
+        linux)
+            secret-tool lookup service "$service" account "$name" 2>/dev/null
+            return $?
+            ;;
+        none)
+            return 1
+            ;;
+    esac
+}
+
+# Check if a secret exists in the OS keychain
+# Usage: _keychain_exists <name> <scope> [project]
+_keychain_exists() {
+    local name="$1"
+    local scope="$2"
+    local project="${3:-}"
+    local service
+    service=$(_keychain_service_name "$scope" "$project")
+    local backend
+    backend=$(_detect_keychain)
+
+    case "$backend" in
+        macos)
+            security find-generic-password -s "$service" -a "$name" &>/dev/null
+            return $?
+            ;;
+        linux)
+            secret-tool lookup service "$service" account "$name" &>/dev/null
+            return $?
+            ;;
+        none)
+            return 1
+            ;;
+    esac
+}
+
+# Remove a secret from the OS keychain
+# Usage: _keychain_remove <name> <scope> [project]
+_keychain_remove() {
+    local name="$1"
+    local scope="$2"
+    local project="${3:-}"
+    local service
+    service=$(_keychain_service_name "$scope" "$project")
+    local backend
+    backend=$(_detect_keychain)
+
+    case "$backend" in
+        macos)
+            security delete-generic-password -s "$service" -a "$name" &>/dev/null
+            return $?
+            ;;
+        linux)
+            secret-tool clear service "$service" account "$name" &>/dev/null
+            return $?
+            ;;
+        none)
+            return 1
+            ;;
+    esac
+}
+
+# List all secret names in a keychain scope
+# Usage: _keychain_list <scope> [project]
+# Outputs: one name per line
+_keychain_list() {
+    local scope="$1"
+    local project="${2:-}"
+    local service
+    service=$(_keychain_service_name "$scope" "$project")
+    local backend
+    backend=$(_detect_keychain)
+
+    case "$backend" in
+        macos)
+            # Parse security dump-keychain output for entries matching our service.
+            # The 0x00000007 line has the service name, "acct" line has the account.
+            # We use sed/grep since macOS awk lacks gawk's match() third arg.
+            local _in_block=false
+            local _line
+            while IFS= read -r _line; do
+                # Service appears on 0x00000007 line or "svce" line
+                if echo "$_line" | grep -q "=\"${service}\""; then
+                    _in_block=true
+                    continue
+                fi
+                if [[ "$_in_block" == true ]] && echo "$_line" | grep -q '"acct"'; then
+                    echo "$_line" | sed 's/.*="\(.*\)"/\1/'
+                    _in_block=false
+                fi
+                # Reset on new entry boundary
+                if echo "$_line" | grep -q '^keychain:'; then
+                    _in_block=false
+                fi
+            done < <(security dump-keychain 2>/dev/null) | sort -u
+            ;;
+        linux)
+            secret-tool search service "$service" 2>/dev/null | \
+                grep "^attribute.account" | \
+                sed 's/.*= //' | sort -u
+            ;;
+        none)
+            return 0
+            ;;
+    esac
+}
+
+# --- Task-scoped secrets (file-based, ephemeral) ---
+
+# Task secrets stay file-based since they're temporary and cleaned up on destroy
+_task_secrets_file() {
+    local sandbox_state="$1"
+    echo "${sandbox_state}.secrets"
+}
+
+_task_secret_exists() {
+    local name="$1"
+    local sandbox_state="$2"
+    local file
+    file=$(_task_secrets_file "$sandbox_state")
     [[ -f "$file" ]] && grep -q "^${name}=" "$file" 2>/dev/null
 }
 
-# Read a secret value from a specific secrets file
-# Usage: _read_secret_from_file <file> <name>
-# Outputs the value (or empty if not found)
-_read_secret_from_file() {
-    local file="$1"
-    local name="$2"
+_task_secret_get() {
+    local name="$1"
+    local sandbox_state="$2"
+    local file
+    file=$(_task_secrets_file "$sandbox_state")
     if [[ -f "$file" ]]; then
         grep "^${name}=" "$file" 2>/dev/null | head -1 | cut -d'=' -f2-
     fi
 }
 
-# Write a secret to a specific secrets file
-# Usage: _write_secret_to_file <file> <name> <value>
-_write_secret_to_file() {
-    local file="$1"
-    local name="$2"
-    local value="$3"
-
-    _ensure_secrets_dirs
+_task_secret_store() {
+    local name="$1"
+    local value="$2"
+    local sandbox_state="$3"
+    local file
+    file=$(_task_secrets_file "$sandbox_state")
 
     # Remove existing entry if present
     if [[ -f "$file" ]]; then
@@ -70,16 +242,15 @@ _write_secret_to_file() {
         mv "$tmp" "$file"
     fi
 
-    # Append new entry
     echo "${name}=${value}" >> "$file"
     chmod 600 "$file"
 }
 
-# Remove a secret from a specific secrets file
-# Usage: _remove_secret_from_file <file> <name>
-_remove_secret_from_file() {
-    local file="$1"
-    local name="$2"
+_task_secret_remove() {
+    local name="$1"
+    local sandbox_state="$2"
+    local file
+    file=$(_task_secrets_file "$sandbox_state")
     if [[ -f "$file" ]]; then
         local tmp="${file}.tmp"
         grep -v "^${name}=" "$file" > "$tmp" 2>/dev/null || true
@@ -88,9 +259,18 @@ _remove_secret_from_file() {
     fi
 }
 
+_task_secret_list() {
+    local sandbox_state="$1"
+    local file
+    file=$(_task_secrets_file "$sandbox_state")
+    if [[ -f "$file" ]]; then
+        grep -v '^#' "$file" 2>/dev/null | grep '=' | cut -d'=' -f1
+    fi
+}
+
 # --- Public API ---
 
-# Check if a secret is available (any scope: task state, project, global)
+# Check if a secret is available (any scope: task, project, global)
 # Usage: secret_exists <name> [project] [sandbox-state-file]
 # Returns: 0 if found, 1 if not
 secret_exists() {
@@ -98,22 +278,18 @@ secret_exists() {
     local project="${2:-}"
     local sandbox_state="${3:-}"
 
-    # Check task-scoped (sandbox state file)
-    if [[ -n "$sandbox_state" ]] && _secret_exists_in_file "$sandbox_state.secrets" "$name"; then
+    # Check task-scoped
+    if [[ -n "$sandbox_state" ]] && _task_secret_exists "$name" "$sandbox_state"; then
         return 0
     fi
 
     # Check project-scoped
-    if [[ -n "$project" ]]; then
-        local pfile
-        pfile=$(_project_secrets_file "$project")
-        if _secret_exists_in_file "$pfile" "$name"; then
-            return 0
-        fi
+    if [[ -n "$project" ]] && _keychain_exists "$name" "project" "$project"; then
+        return 0
     fi
 
     # Check global
-    if _secret_exists_in_file "$GLOBAL_SECRETS" "$name"; then
+    if _keychain_exists "$name" "global"; then
         return 0
     fi
 
@@ -131,20 +307,18 @@ secret_get() {
 
     # Task-scoped
     if [[ -n "$sandbox_state" ]]; then
-        value=$(_read_secret_from_file "$sandbox_state.secrets" "$name")
+        value=$(_task_secret_get "$name" "$sandbox_state")
         [[ -n "$value" ]] && echo "$value" && return 0
     fi
 
     # Project-scoped
     if [[ -n "$project" ]]; then
-        local pfile
-        pfile=$(_project_secrets_file "$project")
-        value=$(_read_secret_from_file "$pfile" "$name")
+        value=$(_keychain_get "$name" "project" "$project")
         [[ -n "$value" ]] && echo "$value" && return 0
     fi
 
     # Global
-    value=$(_read_secret_from_file "$GLOBAL_SECRETS" "$name")
+    value=$(_keychain_get "$name" "global")
     [[ -n "$value" ]] && echo "$value" && return 0
 
     return 1
@@ -160,27 +334,23 @@ secret_store() {
     local project="${4:-}"
     local sandbox_state="${5:-}"
 
-    _ensure_secrets_dirs
-
     case "$scope" in
         global)
-            _write_secret_to_file "$GLOBAL_SECRETS" "$name" "$value"
+            _keychain_store "$name" "$value" "global"
             ;;
         project)
             if [[ -z "$project" ]]; then
                 echo "ERROR: project name required for project scope" >&2
                 return 1
             fi
-            local pfile
-            pfile=$(_project_secrets_file "$project")
-            _write_secret_to_file "$pfile" "$name" "$value"
+            _keychain_store "$name" "$value" "project" "$project"
             ;;
         task)
             if [[ -z "$sandbox_state" ]]; then
                 echo "ERROR: sandbox state file required for task scope" >&2
                 return 1
             fi
-            _write_secret_to_file "$sandbox_state.secrets" "$name" "$value"
+            _task_secret_store "$name" "$value" "$sandbox_state"
             ;;
         *)
             echo "ERROR: unknown scope '$scope'" >&2
@@ -198,16 +368,14 @@ secret_remove() {
 
     case "$scope" in
         global)
-            _remove_secret_from_file "$GLOBAL_SECRETS" "$name"
+            _keychain_remove "$name" "global"
             ;;
         project)
             if [[ -z "$project" ]]; then
                 echo "ERROR: project name required for project scope" >&2
                 return 1
             fi
-            local pfile
-            pfile=$(_project_secrets_file "$project")
-            _remove_secret_from_file "$pfile" "$name"
+            _keychain_remove "$name" "project" "$project"
             ;;
         *)
             echo "ERROR: can only remove from global or project scope" >&2
@@ -225,24 +393,18 @@ secret_list() {
     local names=""
 
     # Global
-    if [[ -f "$GLOBAL_SECRETS" ]]; then
-        names+=$(grep -v '^#' "$GLOBAL_SECRETS" 2>/dev/null | grep '=' | cut -d'=' -f1)
-        names+=$'\n'
-    fi
+    names+=$(_keychain_list "global")
+    names+=$'\n'
 
     # Project
     if [[ -n "$project" ]]; then
-        local pfile
-        pfile=$(_project_secrets_file "$project")
-        if [[ -f "$pfile" ]]; then
-            names+=$(grep -v '^#' "$pfile" 2>/dev/null | grep '=' | cut -d'=' -f1)
-            names+=$'\n'
-        fi
+        names+=$(_keychain_list "project" "$project")
+        names+=$'\n'
     fi
 
     # Task
-    if [[ -n "$sandbox_state" && -f "$sandbox_state.secrets" ]]; then
-        names+=$(grep -v '^#' "$sandbox_state.secrets" 2>/dev/null | grep '=' | cut -d'=' -f1)
+    if [[ -n "$sandbox_state" ]]; then
+        names+=$(_task_secret_list "$sandbox_state")
         names+=$'\n'
     fi
 
@@ -258,36 +420,35 @@ secret_list_with_scope() {
     local project="${1:-}"
     local sandbox_state="${2:-}"
 
-    # Collect from each scope, tracking which scope each came from
     declare -A seen
 
     # Task (narrowest scope - wins over others)
-    if [[ -n "$sandbox_state" && -f "$sandbox_state.secrets" ]]; then
-        while IFS='=' read -r name _; do
-            [[ -z "$name" || "$name" == \#* ]] && continue
+    if [[ -n "$sandbox_state" ]]; then
+        local task_names
+        task_names=$(_task_secret_list "$sandbox_state")
+        while IFS= read -r name; do
+            [[ -z "$name" ]] && continue
             seen["$name"]="task"
-        done < "$sandbox_state.secrets"
+        done <<< "$task_names"
     fi
 
     # Project
     if [[ -n "$project" ]]; then
-        local pfile
-        pfile=$(_project_secrets_file "$project")
-        if [[ -f "$pfile" ]]; then
-            while IFS='=' read -r name _; do
-                [[ -z "$name" || "$name" == \#* ]] && continue
-                [[ -z "${seen[$name]:-}" ]] && seen["$name"]="project"
-            done < "$pfile"
-        fi
+        local proj_names
+        proj_names=$(_keychain_list "project" "$project")
+        while IFS= read -r name; do
+            [[ -z "$name" ]] && continue
+            [[ -z "${seen[$name]:-}" ]] && seen["$name"]="project"
+        done <<< "$proj_names"
     fi
 
     # Global (widest scope)
-    if [[ -f "$GLOBAL_SECRETS" ]]; then
-        while IFS='=' read -r name _; do
-            [[ -z "$name" || "$name" == \#* ]] && continue
-            [[ -z "${seen[$name]:-}" ]] && seen["$name"]="global"
-        done < "$GLOBAL_SECRETS"
-    fi
+    local global_names
+    global_names=$(_keychain_list "global")
+    while IFS= read -r name; do
+        [[ -z "$name" ]] && continue
+        [[ -z "${seen[$name]:-}" ]] && seen["$name"]="global"
+    done <<< "$global_names"
 
     # Output sorted
     for name in $(echo "${!seen[@]}" | tr ' ' '\n' | sort); do

--- a/plugins/openshell/openshell-secrets.sh
+++ b/plugins/openshell/openshell-secrets.sh
@@ -250,6 +250,51 @@ secret_list() {
     echo "$names" | sort -u | grep -v '^$'
 }
 
+# List all secrets with their scope (never values)
+# Usage: secret_list_with_scope [project] [sandbox-state-file]
+# Outputs: "name scope" per line (e.g., "GITHUB_TOKEN global")
+# If a secret exists in multiple scopes, shows the narrowest (task > project > global)
+secret_list_with_scope() {
+    local project="${1:-}"
+    local sandbox_state="${2:-}"
+
+    # Collect from each scope, tracking which scope each came from
+    declare -A seen
+
+    # Task (narrowest scope - wins over others)
+    if [[ -n "$sandbox_state" && -f "$sandbox_state.secrets" ]]; then
+        while IFS='=' read -r name _; do
+            [[ -z "$name" || "$name" == \#* ]] && continue
+            seen["$name"]="task"
+        done < "$sandbox_state.secrets"
+    fi
+
+    # Project
+    if [[ -n "$project" ]]; then
+        local pfile
+        pfile=$(_project_secrets_file "$project")
+        if [[ -f "$pfile" ]]; then
+            while IFS='=' read -r name _; do
+                [[ -z "$name" || "$name" == \#* ]] && continue
+                [[ -z "${seen[$name]:-}" ]] && seen["$name"]="project"
+            done < "$pfile"
+        fi
+    fi
+
+    # Global (widest scope)
+    if [[ -f "$GLOBAL_SECRETS" ]]; then
+        while IFS='=' read -r name _; do
+            [[ -z "$name" || "$name" == \#* ]] && continue
+            [[ -z "${seen[$name]:-}" ]] && seen["$name"]="global"
+        done < "$GLOBAL_SECRETS"
+    fi
+
+    # Output sorted
+    for name in $(echo "${!seen[@]}" | tr ' ' '\n' | sort); do
+        echo "$name ${seen[$name]}"
+    done
+}
+
 # Collect all secrets for a sandbox as --env flags
 # Usage: secret_collect_env_flags [project] [sandbox-state-file]
 # Outputs: --env NAME=value flags for openshell sandbox create

--- a/plugins/openshell/openshell-secrets.sh
+++ b/plugins/openshell/openshell-secrets.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# openshell-secrets.sh - Secret storage helpers for OpenShell plugin
+# Manages .secrets files at global/project/task scopes
+# Secret values NEVER flow through the LLM - only through read -s prompts
+
+set -u
+
+# Read PARA_LLM_ROOT from bootstrap pointer
+BOOTSTRAP_FILE="$HOME/.para-llm-root"
+if [[ -f "$BOOTSTRAP_FILE" ]]; then
+    PARA_LLM_ROOT="$(cat "$BOOTSTRAP_FILE")"
+else
+    echo "para-llm: No bootstrap file found" >&2
+    exit 1
+fi
+
+OPENSHELL_DIR="$PARA_LLM_ROOT/openshell"
+GLOBAL_SECRETS="$OPENSHELL_DIR/.secrets"
+PROJECT_SECRETS_DIR="$OPENSHELL_DIR/secrets"
+
+# Ensure directories and files exist with correct permissions
+_ensure_secrets_dirs() {
+    mkdir -p "$PROJECT_SECRETS_DIR"
+    if [[ ! -f "$GLOBAL_SECRETS" ]]; then
+        touch "$GLOBAL_SECRETS"
+        chmod 600 "$GLOBAL_SECRETS"
+    fi
+}
+
+# Get the path to a project's secrets file
+# Usage: _project_secrets_file <project-name>
+_project_secrets_file() {
+    local project="$1"
+    echo "$PROJECT_SECRETS_DIR/${project}.secrets"
+}
+
+# Check if a secret exists in a specific secrets file
+# Usage: _secret_exists_in_file <file> <name>
+# Returns: 0 if found, 1 if not
+_secret_exists_in_file() {
+    local file="$1"
+    local name="$2"
+    [[ -f "$file" ]] && grep -q "^${name}=" "$file" 2>/dev/null
+}
+
+# Read a secret value from a specific secrets file
+# Usage: _read_secret_from_file <file> <name>
+# Outputs the value (or empty if not found)
+_read_secret_from_file() {
+    local file="$1"
+    local name="$2"
+    if [[ -f "$file" ]]; then
+        grep "^${name}=" "$file" 2>/dev/null | head -1 | cut -d'=' -f2-
+    fi
+}
+
+# Write a secret to a specific secrets file
+# Usage: _write_secret_to_file <file> <name> <value>
+_write_secret_to_file() {
+    local file="$1"
+    local name="$2"
+    local value="$3"
+
+    _ensure_secrets_dirs
+
+    # Remove existing entry if present
+    if [[ -f "$file" ]]; then
+        local tmp="${file}.tmp"
+        grep -v "^${name}=" "$file" > "$tmp" 2>/dev/null || true
+        mv "$tmp" "$file"
+    fi
+
+    # Append new entry
+    echo "${name}=${value}" >> "$file"
+    chmod 600 "$file"
+}
+
+# Remove a secret from a specific secrets file
+# Usage: _remove_secret_from_file <file> <name>
+_remove_secret_from_file() {
+    local file="$1"
+    local name="$2"
+    if [[ -f "$file" ]]; then
+        local tmp="${file}.tmp"
+        grep -v "^${name}=" "$file" > "$tmp" 2>/dev/null || true
+        mv "$tmp" "$file"
+        chmod 600 "$file"
+    fi
+}
+
+# --- Public API ---
+
+# Check if a secret is available (any scope: task state, project, global)
+# Usage: secret_exists <name> [project] [sandbox-state-file]
+# Returns: 0 if found, 1 if not
+secret_exists() {
+    local name="$1"
+    local project="${2:-}"
+    local sandbox_state="${3:-}"
+
+    # Check task-scoped (sandbox state file)
+    if [[ -n "$sandbox_state" ]] && _secret_exists_in_file "$sandbox_state.secrets" "$name"; then
+        return 0
+    fi
+
+    # Check project-scoped
+    if [[ -n "$project" ]]; then
+        local pfile
+        pfile=$(_project_secrets_file "$project")
+        if _secret_exists_in_file "$pfile" "$name"; then
+            return 0
+        fi
+    fi
+
+    # Check global
+    if _secret_exists_in_file "$GLOBAL_SECRETS" "$name"; then
+        return 0
+    fi
+
+    return 1
+}
+
+# Get a secret value (checks scopes in order: task, project, global)
+# Usage: secret_get <name> [project] [sandbox-state-file]
+# Outputs the value
+secret_get() {
+    local name="$1"
+    local project="${2:-}"
+    local sandbox_state="${3:-}"
+    local value=""
+
+    # Task-scoped
+    if [[ -n "$sandbox_state" ]]; then
+        value=$(_read_secret_from_file "$sandbox_state.secrets" "$name")
+        [[ -n "$value" ]] && echo "$value" && return 0
+    fi
+
+    # Project-scoped
+    if [[ -n "$project" ]]; then
+        local pfile
+        pfile=$(_project_secrets_file "$project")
+        value=$(_read_secret_from_file "$pfile" "$name")
+        [[ -n "$value" ]] && echo "$value" && return 0
+    fi
+
+    # Global
+    value=$(_read_secret_from_file "$GLOBAL_SECRETS" "$name")
+    [[ -n "$value" ]] && echo "$value" && return 0
+
+    return 1
+}
+
+# Store a secret at a specific scope
+# Usage: secret_store <name> <value> <scope> [project] [sandbox-state-file]
+# scope: global | project | task
+secret_store() {
+    local name="$1"
+    local value="$2"
+    local scope="$3"
+    local project="${4:-}"
+    local sandbox_state="${5:-}"
+
+    _ensure_secrets_dirs
+
+    case "$scope" in
+        global)
+            _write_secret_to_file "$GLOBAL_SECRETS" "$name" "$value"
+            ;;
+        project)
+            if [[ -z "$project" ]]; then
+                echo "ERROR: project name required for project scope" >&2
+                return 1
+            fi
+            local pfile
+            pfile=$(_project_secrets_file "$project")
+            _write_secret_to_file "$pfile" "$name" "$value"
+            ;;
+        task)
+            if [[ -z "$sandbox_state" ]]; then
+                echo "ERROR: sandbox state file required for task scope" >&2
+                return 1
+            fi
+            _write_secret_to_file "$sandbox_state.secrets" "$name" "$value"
+            ;;
+        *)
+            echo "ERROR: unknown scope '$scope'" >&2
+            return 1
+            ;;
+    esac
+}
+
+# Remove a secret from a specific scope
+# Usage: secret_remove <name> <scope> [project]
+secret_remove() {
+    local name="$1"
+    local scope="$2"
+    local project="${3:-}"
+
+    case "$scope" in
+        global)
+            _remove_secret_from_file "$GLOBAL_SECRETS" "$name"
+            ;;
+        project)
+            if [[ -z "$project" ]]; then
+                echo "ERROR: project name required for project scope" >&2
+                return 1
+            fi
+            local pfile
+            pfile=$(_project_secrets_file "$project")
+            _remove_secret_from_file "$pfile" "$name"
+            ;;
+        *)
+            echo "ERROR: can only remove from global or project scope" >&2
+            return 1
+            ;;
+    esac
+}
+
+# List all secret names (never values) across all scopes
+# Usage: secret_list [project] [sandbox-state-file]
+# Outputs: one name per line (deduplicated)
+secret_list() {
+    local project="${1:-}"
+    local sandbox_state="${2:-}"
+    local names=""
+
+    # Global
+    if [[ -f "$GLOBAL_SECRETS" ]]; then
+        names+=$(grep -v '^#' "$GLOBAL_SECRETS" 2>/dev/null | grep '=' | cut -d'=' -f1)
+        names+=$'\n'
+    fi
+
+    # Project
+    if [[ -n "$project" ]]; then
+        local pfile
+        pfile=$(_project_secrets_file "$project")
+        if [[ -f "$pfile" ]]; then
+            names+=$(grep -v '^#' "$pfile" 2>/dev/null | grep '=' | cut -d'=' -f1)
+            names+=$'\n'
+        fi
+    fi
+
+    # Task
+    if [[ -n "$sandbox_state" && -f "$sandbox_state.secrets" ]]; then
+        names+=$(grep -v '^#' "$sandbox_state.secrets" 2>/dev/null | grep '=' | cut -d'=' -f1)
+        names+=$'\n'
+    fi
+
+    # Deduplicate and output
+    echo "$names" | sort -u | grep -v '^$'
+}
+
+# Collect all secrets for a sandbox as --env flags
+# Usage: secret_collect_env_flags [project] [sandbox-state-file]
+# Outputs: --env NAME=value flags for openshell sandbox create
+secret_collect_env_flags() {
+    local project="${1:-}"
+    local sandbox_state="${2:-}"
+
+    local names
+    names=$(secret_list "$project" "$sandbox_state")
+
+    while IFS= read -r name; do
+        [[ -z "$name" ]] && continue
+        local value
+        value=$(secret_get "$name" "$project" "$sandbox_state") || continue
+        echo "--env"
+        echo "${name}=${value}"
+    done <<< "$names"
+}

--- a/plugins/openshell/openshell-status.sh
+++ b/plugins/openshell/openshell-status.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# openshell-status.sh - tmux status-right segment for OpenShell
+# Shows count of active sandboxes (e.g., "OS:2")
+# Called by tmux status-right: #(path/to/openshell-status.sh)
+
+set -u
+
+# Read PARA_LLM_ROOT from bootstrap pointer
+BOOTSTRAP_FILE="$HOME/.para-llm-root"
+if [[ ! -f "$BOOTSTRAP_FILE" ]]; then
+    exit 0
+fi
+PARA_LLM_ROOT="$(cat "$BOOTSTRAP_FILE")"
+
+# Source config
+if [[ -f "$PARA_LLM_ROOT/config" ]]; then
+    source "$PARA_LLM_ROOT/config"
+fi
+
+# Exit if OpenShell not enabled
+if [[ "${OPENSHELL_ENABLED:-0}" != "1" ]]; then
+    exit 0
+fi
+
+SANDBOX_STATE_DIR="$PARA_LLM_ROOT/openshell/state/sandboxes"
+
+# Count active sandbox state files
+count=0
+if [[ -d "$SANDBOX_STATE_DIR" ]]; then
+    for f in "$SANDBOX_STATE_DIR"/*; do
+        [[ -f "$f" ]] && (( count++ ))
+    done
+fi
+
+# Only show if there are active sandboxes
+if [[ $count -gt 0 ]]; then
+    echo "OS:${count}"
+fi

--- a/plugins/openshell/openshell-sync.sh
+++ b/plugins/openshell/openshell-sync.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# openshell-sync.sh - File sync helpers for upload strategy
+# Used when OPENSHELL_SYNC_STRATEGY=upload
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/openshell-sandbox.sh"
+
+# Sync files from host to sandbox
+# Usage: sync_to_sandbox <sandbox-name> <local-dir> [remote-dir]
+sync_to_sandbox() {
+    local sandbox_name="$1"
+    local local_dir="$2"
+    local remote_dir="${3:-/workspace/}"
+
+    if ! openshell_available; then
+        echo "ERROR: openshell not available" >&2
+        return 1
+    fi
+
+    echo "Uploading to sandbox '$sandbox_name'..." >&2
+    openshell sandbox upload "$sandbox_name" "$local_dir" "$remote_dir"
+    return $?
+}
+
+# Sync files from sandbox to host
+# Usage: sync_from_sandbox <sandbox-name> <local-dir> [remote-dir]
+sync_from_sandbox() {
+    local sandbox_name="$1"
+    local local_dir="$2"
+    local remote_dir="${3:-/workspace/}"
+
+    if ! openshell_available; then
+        echo "ERROR: openshell not available" >&2
+        return 1
+    fi
+
+    echo "Downloading from sandbox '$sandbox_name'..." >&2
+    openshell sandbox download "$sandbox_name" "$remote_dir" "$local_dir"
+    return $?
+}
+
+# Bidirectional sync (upload then download)
+# Usage: sync_bidirectional <sandbox-name> <local-dir> [remote-dir]
+sync_bidirectional() {
+    local sandbox_name="$1"
+    local local_dir="$2"
+    local remote_dir="${3:-/workspace/}"
+
+    sync_to_sandbox "$sandbox_name" "$local_dir" "$remote_dir" && \
+    sync_from_sandbox "$sandbox_name" "$local_dir" "$remote_dir"
+}

--- a/plugins/openshell/para-llm-secrets
+++ b/plugins/openshell/para-llm-secrets
@@ -45,10 +45,25 @@ cmd_add() {
     local project
     project=$(detect_project)
 
-    # Read value silently
+    # Read value with masked input (shows * per character)
     printf "Value for %s: " "$name"
-    IFS= read -r -s value
-    echo ""
+    value=""
+    while true; do
+        IFS= read -r -s -n 1 ch
+        if [[ "$ch" == "" ]]; then
+            echo ""
+            break
+        fi
+        if [[ "$ch" == $'\177' || "$ch" == $'\b' ]]; then
+            if [[ -n "$value" ]]; then
+                value="${value%?}"
+                printf '\b \b'
+            fi
+            continue
+        fi
+        value+="$ch"
+        printf '*'
+    done
 
     if [[ -z "$value" ]]; then
         echo "Cancelled (empty value)."

--- a/plugins/openshell/para-llm-secrets
+++ b/plugins/openshell/para-llm-secrets
@@ -141,17 +141,17 @@ cmd_remove() {
 cmd_list() {
     local project
     project=$(detect_project)
-    local names
-    names=$(secret_list "$project")
+    local entries
+    entries=$(secret_list_with_scope "$project")
 
-    if [[ -z "$names" ]]; then
+    if [[ -z "$entries" ]]; then
         echo "No secrets registered."
     else
         echo "Registered secrets:"
-        while IFS= read -r name; do
+        while IFS=' ' read -r name scope; do
             [[ -z "$name" ]] && continue
-            echo "  - $name"
-        done <<< "$names"
+            echo "  - $name ($scope)"
+        done <<< "$entries"
     fi
 }
 

--- a/plugins/openshell/para-llm-secrets
+++ b/plugins/openshell/para-llm-secrets
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# para-llm-secrets - Standalone CLI for secret management
+# Use via: ! para-llm-secrets add/remove/list
+# The ! prefix in Claude Code drops to shell, so secret values never touch the LLM
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/openshell-secrets.sh"
+
+# Try to detect current project from CWD
+detect_project() {
+    local envs_dir="${PARA_LLM_ROOT}/envs"
+    local cwd="${PWD:-}"
+
+    if [[ "$cwd" == "$envs_dir"* ]]; then
+        local rel="${cwd#$envs_dir/}"
+        local env_name="${rel%%/*}"
+        echo "${env_name%%-*}"
+    fi
+}
+
+usage() {
+    echo "Usage: para-llm-secrets <command> [args]"
+    echo ""
+    echo "Commands:"
+    echo "  add <NAME>      Register a secret (prompts for value with silent input)"
+    echo "  remove <NAME>   Remove a secret from a specific scope"
+    echo "  list            List all registered secret names (never shows values)"
+    echo "  check <NAME>    Check if a secret is registered"
+    echo ""
+    echo "Scope is selected interactively for add/remove."
+    echo ""
+    echo "Usage from Claude Code REPL:"
+    echo "  ! para-llm-secrets add GITHUB_TOKEN"
+}
+
+cmd_add() {
+    local name="${1:-}"
+    if [[ -z "$name" ]]; then
+        echo "Usage: para-llm-secrets add <SECRET_NAME>"
+        return 1
+    fi
+
+    local project
+    project=$(detect_project)
+
+    # Read value silently
+    printf "Value for %s: " "$name"
+    IFS= read -r -s value
+    echo ""
+
+    if [[ -z "$value" ]]; then
+        echo "Cancelled (empty value)."
+        return 1
+    fi
+
+    # Select scope
+    echo ""
+    echo "Register for:"
+    echo "  1) This project${project:+ ($project)}"
+    echo "  2) All projects (global)"
+    printf "Choice [1]: "
+    read -r choice
+
+    case "${choice:-1}" in
+        1)
+            if [[ -n "$project" ]]; then
+                secret_store "$name" "$value" "project" "$project"
+                echo "Secret '$name' registered for project '$project'."
+            else
+                secret_store "$name" "$value" "global"
+                echo "Secret '$name' registered globally (no project context detected)."
+            fi
+            ;;
+        2)
+            secret_store "$name" "$value" "global"
+            echo "Secret '$name' registered globally."
+            ;;
+        *)
+            echo "Cancelled."
+            return 1
+            ;;
+    esac
+
+    # Clear value from memory
+    value=""
+}
+
+cmd_remove() {
+    local name="${1:-}"
+    if [[ -z "$name" ]]; then
+        echo "Usage: para-llm-secrets remove <SECRET_NAME>"
+        return 1
+    fi
+
+    local project
+    project=$(detect_project)
+
+    echo "Remove '$name' from:"
+    echo "  1) This project${project:+ ($project)}"
+    echo "  2) All projects (global)"
+    printf "Choice [1]: "
+    read -r choice
+
+    case "${choice:-1}" in
+        1)
+            if [[ -n "$project" ]]; then
+                secret_remove "$name" "project" "$project"
+                echo "Secret '$name' removed from project '$project'."
+            else
+                echo "No project context detected. Use choice 2 for global."
+                return 1
+            fi
+            ;;
+        2)
+            secret_remove "$name" "global"
+            echo "Secret '$name' removed globally."
+            ;;
+        *)
+            echo "Cancelled."
+            ;;
+    esac
+}
+
+cmd_list() {
+    local project
+    project=$(detect_project)
+    local names
+    names=$(secret_list "$project")
+
+    if [[ -z "$names" ]]; then
+        echo "No secrets registered."
+    else
+        echo "Registered secrets:"
+        while IFS= read -r name; do
+            [[ -z "$name" ]] && continue
+            echo "  - $name"
+        done <<< "$names"
+    fi
+}
+
+cmd_check() {
+    local name="${1:-}"
+    if [[ -z "$name" ]]; then
+        echo "Usage: para-llm-secrets check <SECRET_NAME>"
+        return 1
+    fi
+
+    local project
+    project=$(detect_project)
+
+    if secret_exists "$name" "$project"; then
+        echo "Secret '$name' is registered."
+        return 0
+    else
+        echo "Secret '$name' is NOT registered."
+        return 1
+    fi
+}
+
+# --- Main ---
+
+command="${1:-}"
+shift 2>/dev/null || true
+
+case "$command" in
+    add)    cmd_add "$@" ;;
+    remove) cmd_remove "$@" ;;
+    list)   cmd_list ;;
+    check)  cmd_check "$@" ;;
+    -h|--help|help|"")
+        usage
+        ;;
+    *)
+        echo "Unknown command: $command"
+        usage
+        exit 1
+        ;;
+esac

--- a/plugins/openshell/policies/default.yaml
+++ b/plugins/openshell/policies/default.yaml
@@ -1,0 +1,77 @@
+version: 1
+
+filesystem_policy:
+  include_workdir: true
+  read_only:
+    - /usr
+    - /lib
+    - /lib64
+    - /bin
+    - /sbin
+    - /etc
+  read_write:
+    - /sandbox
+    - /tmp
+    - /home
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+landlock:
+  compatibility: best_effort
+
+network_policies:
+  anthropic_api:
+    name: anthropic-api
+    endpoints:
+      - host: api.anthropic.com
+        port: 443
+      - host: "*.anthropic.com"
+        port: 443
+    binaries:
+      - path: /usr/local/bin/claude
+      - path: /usr/bin/node
+      - path: /usr/bin/curl
+
+  github:
+    name: github
+    endpoints:
+      - host: github.com
+        port: 443
+      - host: github.com
+        port: 22
+      - host: "*.github.com"
+        port: 443
+      - host: "*.githubusercontent.com"
+        port: 443
+    binaries:
+      - path: /usr/bin/git
+      - path: /usr/bin/ssh
+      - path: /usr/bin/gh
+      - path: /usr/local/bin/gh
+      - path: /usr/local/bin/claude
+
+  npm_registry:
+    name: npm-registry
+    endpoints:
+      - host: registry.npmjs.org
+        port: 443
+      - host: "*.npmjs.org"
+        port: 443
+    binaries:
+      - path: /usr/bin/npm
+      - path: /usr/local/bin/npm
+      - path: /usr/bin/node
+
+  pypi:
+    name: pypi
+    endpoints:
+      - host: pypi.org
+        port: 443
+      - host: files.pythonhosted.org
+        port: 443
+    binaries:
+      - path: /usr/bin/pip
+      - path: /usr/local/bin/pip
+      - path: /usr/local/bin/uv

--- a/plugins/openshell/policies/permissive.yaml
+++ b/plugins/openshell/policies/permissive.yaml
@@ -1,0 +1,86 @@
+version: 1
+
+filesystem_policy:
+  include_workdir: true
+  read_only:
+    - /usr
+    - /lib
+    - /lib64
+    - /bin
+    - /sbin
+    - /etc
+  read_write:
+    - /sandbox
+    - /tmp
+    - /home
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+landlock:
+  compatibility: best_effort
+
+network_policies:
+  anthropic_api:
+    name: anthropic-api
+    endpoints:
+      - host: api.anthropic.com
+        port: 443
+      - host: "*.anthropic.com"
+        port: 443
+    binaries:
+      - path: "**"
+
+  github:
+    name: github
+    endpoints:
+      - host: github.com
+        port: 443
+      - host: github.com
+        port: 22
+      - host: "*.github.com"
+        port: 443
+      - host: "*.githubusercontent.com"
+        port: 443
+    binaries:
+      - path: "**"
+
+  npm_registry:
+    name: npm-registry
+    endpoints:
+      - host: registry.npmjs.org
+        port: 443
+      - host: "*.npmjs.org"
+        port: 443
+    binaries:
+      - path: "**"
+
+  pypi:
+    name: pypi
+    endpoints:
+      - host: pypi.org
+        port: 443
+      - host: files.pythonhosted.org
+        port: 443
+    binaries:
+      - path: "**"
+
+  docker_hub:
+    name: docker-hub
+    endpoints:
+      - host: "*.docker.io"
+        port: 443
+      - host: "*.docker.com"
+        port: 443
+    binaries:
+      - path: "**"
+
+  general_https:
+    name: general-https
+    endpoints:
+      - host: "*"
+        port: 443
+        enforcement: audit
+    binaries:
+      - path: "**"

--- a/tmux-cleanup-branch.sh
+++ b/tmux-cleanup-branch.sh
@@ -167,6 +167,18 @@ main() {
                     fi
                 done
 
+                # Destroy OpenShell sandbox if this env was sandboxed
+                local openshell_plugin="$SCRIPT_DIR/plugins/openshell/openshell-sandbox.sh"
+                if [[ -f "$openshell_plugin" ]]; then
+                    # Extract project name (everything before first dash in env name)
+                    local project_name="${ENV_NAME%%-*}"
+                    source "$openshell_plugin"
+                    if is_env_sandboxed "$project_name" "$BRANCH_NAME"; then
+                        echo "Destroying OpenShell sandbox..."
+                        sandbox_destroy "$project_name" "$BRANCH_NAME" "$ENV_DIR/${project_name}" || true
+                    fi
+                fi
+
                 # Kill any tmux windows/panes with this branch name
                 if in_command_center; then
                     # In command center: find and kill the pane for this branch

--- a/tmux-new-branch.sh
+++ b/tmux-new-branch.sh
@@ -32,10 +32,20 @@ launch_claude_in_env() {
 
     local claude_cmd="claude --dangerously-skip-permissions${resume_flag}"
 
-    # Check if OpenShell is enabled
+    # Check if OpenShell is enabled and available
     local openshell_enabled="${OPENSHELL_ENABLED:-0}"
-    if [[ "$openshell_enabled" != "1" ]]; then
-        # Standard host execution
+    local openshell_plugin="$SCRIPT_DIR/plugins/openshell/openshell-sandbox.sh"
+    local openshell_ready=false
+
+    if [[ "$openshell_enabled" == "1" && -f "$openshell_plugin" ]]; then
+        source "$openshell_plugin"
+        if openshell_available && docker_available; then
+            openshell_ready=true
+        fi
+    fi
+
+    if [[ "$openshell_ready" != true ]]; then
+        # OpenShell not enabled or not available - standard host execution
         if [[ "$has_setup_hook" == true && -f "$clone_dir/paraLlm_setup.sh" ]]; then
             tmux send-keys "./paraLlm_setup.sh && $claude_cmd" Enter
         else
@@ -44,7 +54,7 @@ launch_claude_in_env() {
         return
     fi
 
-    # OpenShell enabled - decide whether to sandbox
+    # OpenShell available - decide whether to sandbox
     local use_sandbox=false
     local auto_sandbox="${OPENSHELL_AUTO_SANDBOX:-0}"
 
@@ -71,16 +81,6 @@ launch_claude_in_env() {
     fi
 
     # --- Sandbox execution ---
-    # Source sandbox helpers
-    local openshell_plugin="$SCRIPT_DIR/plugins/openshell/openshell-sandbox.sh"
-    if [[ ! -f "$openshell_plugin" ]]; then
-        echo "OpenShell plugin not found at $openshell_plugin"
-        echo "Falling back to host execution..."
-        sleep 2
-        tmux send-keys "$claude_cmd" Enter
-        return
-    fi
-    source "$openshell_plugin"
 
     # Check if sandbox already exists (for resume)
     if sandbox_exists "$project_name" "$branch_name"; then
@@ -95,8 +95,8 @@ launch_claude_in_env() {
         sname=$(sandbox_name_for_env "$project_name" "$branch_name")
         tmux send-keys "openshell sandbox connect $sname" Enter
     else
-        echo "Sandbox creation failed, falling back to host execution..."
-        sleep 2
+        echo "Sandbox creation failed. Starting on host instead..."
+        sleep 1
         if [[ "$has_setup_hook" == true && -f "$clone_dir/paraLlm_setup.sh" ]]; then
             tmux send-keys "./paraLlm_setup.sh && $claude_cmd" Enter
         else

--- a/tmux-new-branch.sh
+++ b/tmux-new-branch.sh
@@ -10,6 +10,101 @@ source "$SCRIPT_DIR/para-llm-config.sh"
 # Ensure envs directory exists
 mkdir -p "$ENVS_DIR"
 
+# --- OpenShell integration helper ---
+# Launches Claude either directly or inside an OpenShell sandbox
+# Usage: launch_claude_in_env <clone-dir> <env-dir> <branch-name> <project-name> [--resume] [--setup-hook]
+launch_claude_in_env() {
+    local clone_dir="$1"
+    local env_dir="$2"
+    local branch_name="$3"
+    local project_name="$4"
+    local resume_flag=""
+    local has_setup_hook=false
+
+    shift 4
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --resume) resume_flag=" --resume" ;;
+            --setup-hook) has_setup_hook=true ;;
+        esac
+        shift
+    done
+
+    local claude_cmd="claude --dangerously-skip-permissions${resume_flag}"
+
+    # Check if OpenShell is enabled
+    local openshell_enabled="${OPENSHELL_ENABLED:-0}"
+    if [[ "$openshell_enabled" != "1" ]]; then
+        # Standard host execution
+        if [[ "$has_setup_hook" == true && -f "$clone_dir/paraLlm_setup.sh" ]]; then
+            tmux send-keys "./paraLlm_setup.sh && $claude_cmd" Enter
+        else
+            tmux send-keys "$claude_cmd" Enter
+        fi
+        return
+    fi
+
+    # OpenShell enabled - decide whether to sandbox
+    local use_sandbox=false
+    local auto_sandbox="${OPENSHELL_AUTO_SANDBOX:-0}"
+
+    if [[ "$auto_sandbox" == "1" ]]; then
+        use_sandbox=true
+    else
+        # Ask user via fzf
+        local sandbox_choice
+        sandbox_choice=$(printf "Host (no sandbox)\nOpenShell Sandbox" | \
+            fzf --prompt="Run environment in: " --height=6 --no-info)
+        if [[ "$sandbox_choice" == "OpenShell Sandbox" ]]; then
+            use_sandbox=true
+        fi
+    fi
+
+    if [[ "$use_sandbox" == false ]]; then
+        # Standard host execution
+        if [[ "$has_setup_hook" == true && -f "$clone_dir/paraLlm_setup.sh" ]]; then
+            tmux send-keys "./paraLlm_setup.sh && $claude_cmd" Enter
+        else
+            tmux send-keys "$claude_cmd" Enter
+        fi
+        return
+    fi
+
+    # --- Sandbox execution ---
+    # Source sandbox helpers
+    local openshell_plugin="$SCRIPT_DIR/plugins/openshell/openshell-sandbox.sh"
+    if [[ ! -f "$openshell_plugin" ]]; then
+        echo "OpenShell plugin not found at $openshell_plugin"
+        echo "Falling back to host execution..."
+        sleep 2
+        tmux send-keys "$claude_cmd" Enter
+        return
+    fi
+    source "$openshell_plugin"
+
+    # Check if sandbox already exists (for resume)
+    if sandbox_exists "$project_name" "$branch_name"; then
+        echo "Reconnecting to existing sandbox..."
+        tmux send-keys "openshell sandbox connect $(sandbox_name_for_env "$project_name" "$branch_name")" Enter
+        return
+    fi
+
+    # Create sandbox
+    if sandbox_create "$project_name" "$branch_name" "$env_dir" "$clone_dir"; then
+        local sname
+        sname=$(sandbox_name_for_env "$project_name" "$branch_name")
+        tmux send-keys "openshell sandbox connect $sname" Enter
+    else
+        echo "Sandbox creation failed, falling back to host execution..."
+        sleep 2
+        if [[ "$has_setup_hook" == true && -f "$clone_dir/paraLlm_setup.sh" ]]; then
+            tmux send-keys "./paraLlm_setup.sh && $claude_cmd" Enter
+        else
+            tmux send-keys "$claude_cmd" Enter
+        fi
+    fi
+}
+
 # Check if we're currently in command center (matches cleanup script approach)
 COMMAND_CENTER="command-center"
 
@@ -312,7 +407,7 @@ main() {
                     PROJECT_NAME="$selected_env"
                     local window_name="${PROJECT_NAME} multi-repo (${REPO_COUNT})"
                     create_feature_window "$window_name" "$ENV_DIR"
-                    tmux send-keys "claude --dangerously-skip-permissions --resume" Enter
+                    launch_claude_in_env "$ENV_DIR" "$ENV_DIR" "$selected_env" "$PROJECT_NAME" --resume
                     exit 0
                 else
                     # Step 3a: Select existing branch for this project
@@ -328,12 +423,7 @@ main() {
                     CLONE_DIR="${ENV_DIR}/${REPO_NAME}"
 
                     create_feature_window "$BRANCH_NAME" "$CLONE_DIR"
-                    # Run setup hook if it exists
-                    if [[ -f "$CLONE_DIR/paraLlm_setup.sh" ]]; then
-                        tmux send-keys "./paraLlm_setup.sh && claude --dangerously-skip-permissions --resume" Enter
-                    else
-                        tmux send-keys "claude --dangerously-skip-permissions --resume" Enter
-                    fi
+                    launch_claude_in_env "$CLONE_DIR" "$ENV_DIR" "$BRANCH_NAME" "$REPO_NAME" --resume --setup-hook
                     exit 0
                 fi
                 ;;
@@ -402,15 +492,11 @@ main() {
                     create_multi_repo_claude_md "$ENV_DIR" "$BRANCH_NAME" "${REPO_NAMES[@]}"
                     local window_name="${PROJECT_NAME} multi-repo (${REPO_COUNT})"
                     create_feature_window "$window_name" "$ENV_DIR"
-                    tmux send-keys "claude --dangerously-skip-permissions" Enter
+                    launch_claude_in_env "$ENV_DIR" "$ENV_DIR" "$BRANCH_NAME" "$PROJECT_NAME"
                 else
                     CLONE_DIR="$primary_clone_dir"
                     create_feature_window "$BRANCH_NAME" "$CLONE_DIR"
-                    if [[ -f "$CLONE_DIR/paraLlm_setup.sh" ]]; then
-                        tmux send-keys "./paraLlm_setup.sh && claude --dangerously-skip-permissions" Enter
-                    else
-                        tmux send-keys "claude --dangerously-skip-permissions" Enter
-                    fi
+                    launch_claude_in_env "$CLONE_DIR" "$ENV_DIR" "$BRANCH_NAME" "$REPO_NAME" --setup-hook
                 fi
                 exit 0
                 ;;
@@ -449,15 +535,11 @@ main() {
                     if [[ "$IS_MULTI_REPO" == true ]]; then
                         local window_name="${PROJECT_NAME} multi-repo (${REPO_COUNT})"
                         create_feature_window "$window_name" "$ENV_DIR"
-                        tmux send-keys "claude --dangerously-skip-permissions --resume" Enter
+                        launch_claude_in_env "$ENV_DIR" "$ENV_DIR" "$BRANCH_NAME" "$PROJECT_NAME" --resume
                     else
                         CLONE_DIR="${ENV_DIR}/${REPO_NAME}"
                         create_feature_window "$BRANCH_NAME" "$CLONE_DIR"
-                        if [[ -f "$CLONE_DIR/paraLlm_setup.sh" ]]; then
-                            tmux send-keys "./paraLlm_setup.sh && claude --dangerously-skip-permissions --resume" Enter
-                        else
-                            tmux send-keys "claude --dangerously-skip-permissions --resume" Enter
-                        fi
+                        launch_claude_in_env "$CLONE_DIR" "$ENV_DIR" "$BRANCH_NAME" "$REPO_NAME" --resume --setup-hook
                     fi
                     exit 0
                 fi
@@ -512,15 +594,11 @@ main() {
                     create_multi_repo_claude_md "$ENV_DIR" "$BRANCH_NAME" "${REPO_NAMES[@]}"
                     local window_name="${PROJECT_NAME} multi-repo (${REPO_COUNT})"
                     create_feature_window "$window_name" "$ENV_DIR"
-                    tmux send-keys "claude --dangerously-skip-permissions" Enter
+                    launch_claude_in_env "$ENV_DIR" "$ENV_DIR" "$BRANCH_NAME" "$PROJECT_NAME"
                 else
                     CLONE_DIR="$primary_clone_dir"
                     create_feature_window "$BRANCH_NAME" "$CLONE_DIR"
-                    if [[ -f "$CLONE_DIR/paraLlm_setup.sh" ]]; then
-                        tmux send-keys "./paraLlm_setup.sh && claude --dangerously-skip-permissions" Enter
-                    else
-                        tmux send-keys "claude --dangerously-skip-permissions" Enter
-                    fi
+                    launch_claude_in_env "$CLONE_DIR" "$ENV_DIR" "$BRANCH_NAME" "$REPO_NAME" --setup-hook
                 fi
                 exit 0
                 ;;


### PR DESCRIPTION
## Summary
- Adds optional `plugins/openshell/` plugin to run Claude Code environments inside NVIDIA OpenShell sandboxes with kernel-level isolation (Landlock, seccomp, network policies)
- Introduces MCP secret server: Claude detects auth errors and calls `register_secret` tool, which spawns a tmux popup for secure value entry — secret values never touch the LLM
- Integrates with existing `Ctrl+b c` (create), `Ctrl+b k` (cleanup), and Command Center flows; adds `Ctrl+b o` management menu
- All existing behavior unchanged when `OPENSHELL_ENABLED=0` (default)

## New files (11)
- `plugins/openshell/openshell-sandbox.sh` — Sandbox lifecycle (create/connect/destroy/status)
- `plugins/openshell/openshell-gateway.sh` — Gateway health checks
- `plugins/openshell/openshell-secrets.sh` — Secret storage at global/project/task scopes
- `plugins/openshell/openshell-manage.sh` — fzf management menu (Ctrl+b o)
- `plugins/openshell/openshell-status.sh` — tmux status bar segment
- `plugins/openshell/openshell-sync.sh` — File sync helpers for upload strategy
- `plugins/openshell/para-llm-secrets` — Standalone CLI (`! para-llm-secrets add`)
- `plugins/openshell/mcp-secret-server/server.sh` — MCP server (register_secret, list_secrets, check_secret)
- `plugins/openshell/mcp-secret-server/popup-register.sh` — Secure tmux popup for secret entry
- `plugins/openshell/policies/default.yaml` — Restrictive default policy
- `plugins/openshell/policies/permissive.yaml` — Wider access with audit mode

## Modified files (5)
- `tmux-new-branch.sh` — Added `launch_claude_in_env()` helper with sandbox decision flow
- `tmux-cleanup-branch.sh` — Added sandbox destruction on environment cleanup
- `install.sh` — OpenShell plugin setup (prompt, dirs, MCP registration, keybinding, status)
- `plugins/claude-state-monitor/state-detector.sh` — Sandbox indicator in pane borders
- `envs.sh` — `[sandboxed]` indicator in environment status

## Test plan
- [ ] Run `install.sh`, enable OpenShell plugin, verify config and dirs created
- [ ] Create sandboxed env via `Ctrl+b c` → verify sandbox in `openshell sandbox list`
- [ ] Resume sandboxed env → verify reconnects to existing sandbox
- [ ] Cleanup sandboxed env via `Ctrl+b k` → verify sandbox deleted
- [ ] Disable Docker → verify graceful fallback to host execution
- [ ] `Ctrl+b o` → verify management menu works (list, secrets, gateway status)
- [ ] Trigger auth error in sandbox → verify `register_secret` MCP tool popup
- [ ] Set `OPENSHELL_ENABLED=0` → verify entire existing workflow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)