### PR TITLE
Fix command view failing to restore 7th+ windows on close

### DIFF
--- a/tmux-command-center.sh
+++ b/tmux-command-center.sh
@@ -113,10 +113,22 @@ restore_command_center() {
 
         # Check if this pane still exists
         if tmux list-panes -a -F '#{pane_id}' 2>/dev/null | grep -qx "$pane_id"; then
-            # Break pane out to a new window with its original name
-            if tmux break-pane -s "$pane_id" -n "$name" 2>/dev/null; then
-                ((restored++))
-                # Remember first restored window
+            local success=false
+            # If this pane is the last one in command-center, rename the window instead
+            # of breaking it out — some tmux versions refuse break-pane on the last pane,
+            # which silently fails and leaves the 7th+ window with a wrong name.
+            local cc_count
+            cc_count=$(tmux list-panes -t "$COMMAND_CENTER" 2>/dev/null | wc -l | tr -d ' ')
+            if [[ "${cc_count:-0}" -eq 1 ]] && \
+               tmux list-panes -t "$COMMAND_CENTER" -F '#{pane_id}' 2>/dev/null | grep -qx "$pane_id"; then
+                # Last pane in command-center: rename the window to preserve the name
+                tmux rename-window -t "$COMMAND_CENTER" "$name" 2>/dev/null && success=true
+            else
+                # Use -d to avoid switching focus on each break, keeping the loop stable
+                tmux break-pane -s "$pane_id" -n "$name" -d 2>/dev/null && success=true
+            fi
+            if $success; then
+                ((restored++)) || true
                 if [[ -z "$first_restored_window" ]]; then
                     first_restored_window="$name"
                 fi
@@ -131,7 +143,7 @@ restore_command_center() {
         tmux list-panes -t "$COMMAND_CENTER" -F '#{pane_id}|#{pane_current_path}' 2>/dev/null | while IFS='|' read -r remain_id remain_path; do
             local remain_name
             remain_name=$(basename "$remain_path")
-            tmux break-pane -s "$remain_id" -n "$remain_name" 2>/dev/null || true
+            tmux break-pane -s "$remain_id" -n "$remain_name" -d 2>/dev/null || true
         done
     fi
 


### PR DESCRIPTION
## Summary
- `break-pane` on the last pane in command-center fails silently in some tmux versions, causing the 7th+ window to be restored with a wrong path-derived name instead of its saved name
- Fixed by detecting the last-pane case and using `rename-window` instead of `break-pane`
- Added `-d` flag to all `break-pane` calls in the restore loop to prevent focus-switching between iterations, which was making the loop unstable

## Test plan
- [ ] Open 7+ windows in a tmux session
- [ ] Open command view (`Ctrl+b v`)
- [ ] Close command view (`Ctrl+b v` from within command-center)
- [ ] Verify all 7+ windows are restored with their correct original names

🤖 Generated with [Claude Code](https://claude.com/claude-code)