### PR TITLE
Add REPL switching and voice controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # para-llm-directory
 
-Tmux workflow for managing parallel Claude Code sessions across multiple feature branches.
+Tmux workflow for managing parallel Claude Code or Codex sessions across multiple feature branches.
 
 <img width="1512" height="977" alt="Screenshot 2026-03-26 at 8 37 41 PM" src="https://github.com/user-attachments/assets/0c976b6a-d33a-4ec3-ac01-77c402f67e70" />
 
@@ -10,7 +10,8 @@ Tmux workflow for managing parallel Claude Code sessions across multiple feature
   - Select a project from `~/code`
   - Choose to start new or resume existing feature
   - Clones repo to `~/code/envs/{Project}-{feature}/{Project}/`
-  - Opens tmux window and starts Claude Code
+  - Choose Claude Code or Codex for the new worktree
+  - Opens tmux window and starts the selected REPL
 
 - **Ctrl+b k**: Cleanup a feature branch environment
   - Select feature to delete
@@ -20,6 +21,9 @@ Tmux workflow for managing parallel Claude Code sessions across multiple feature
 
 - **Ctrl+b C**: Plain new window (original tmux behavior)
 
+- **Ctrl+b y**: Choose or switch the active worktree between Claude Code and Codex
+- **Ctrl+b a**: Voice input with whisper.cpp (press once to record, again to transcribe)
+- **Ctrl+b p**: Voice playback for the latest active pane output
 - **Shift+Enter**: Insert newline in Claude Code REPL (requires iTerm2 with CSI u — see below)
 - **Mouse/trackpad**: Scroll tmux panes and click to select panes
 - **Option+drag**: Select and copy text (Cmd+C to copy, iTerm2 native selection)
@@ -41,6 +45,15 @@ brew install fzf
 
 # Install Claude Code
 npm install -g @anthropic-ai/claude-code
+
+# Optional: Install Codex if you want Codex terminals
+npm install -g @openai/codex
+
+# Voice input dependencies
+brew install sox whisper-cpp
+
+# Voice playback dependency
+pipx install edge-tts
 ```
 
 ## Installation
@@ -107,7 +120,7 @@ mkdir -p ~/code/envs
 3. Choose "No - start new feature/bug"
 4. Enter the feature/branch name
 5. Wait for clone to complete
-6. Claude Code starts automatically
+6. The selected REPL starts automatically
 
 ### Resuming work on a feature
 
@@ -115,7 +128,37 @@ mkdir -p ~/code/envs
 2. Select your project
 3. Choose "Yes - resume existing"
 4. Select the branch from the list
-5. Claude Code resumes with `--resume`
+5. The stored REPL for that environment resumes automatically
+
+### Switching between Claude and Codex
+
+From a worktree pane, press `Ctrl+b y` and choose Claude Code or Codex. The choice is stored per environment:
+
+```text
+.para-llm/
+  repl
+  transcript.log
+  handoff.md
+```
+
+When switching from one product to the other, para-llm captures the pane transcript, writes `.para-llm/handoff.md`, and starts the selected REPL with a prompt to continue from that handoff. This transfers working context, not the product's hidden conversation state.
+
+### Voice
+
+- Press `Ctrl+b a` to start recording, then `Ctrl+b a` again to transcribe into the active pane.
+- Press `Ctrl+b p` to speak the latest readable output from the active pane, then `Ctrl+b p` again to stop playback.
+
+Voice is always installed by `install.sh`. STT uses `sox` and `whisper-cpp`. TTS uses Microsoft `edge-tts` with `en-US-AndrewNeural` by default and plays audio with `afplay` on macOS. Before playback, para-llm asks the selected REPL backend to turn the latest pane text into concise speakable prose, so code blocks, diffs, logs, and long output are summarized instead of read verbatim. While TTS is preparing the summary and audio, para-llm plays a subtle repeating click so you know playback is working before the first utterance. If summarization is unavailable, playback falls back to the extracted pane text.
+
+### Upgrading existing environments
+
+After installing, run:
+
+```bash
+$PARA_LLM_ROOT/scripts/para-llm-upgrade-envs.sh
+```
+
+This creates `.para-llm/` metadata for existing envs, defaults missing REPL choices to Claude, creates `AGENTS.md` from `CLAUDE.md` when needed, and attaches transcript logging to currently open panes.
 
 ### Cleaning up a finished feature
 
@@ -137,7 +180,7 @@ Projects can define setup and teardown scripts that run automatically:
 
 ### `paraLlm_setup.sh`
 
-If this script exists in your project root, it runs when creating or resuming an environment (before Claude starts).
+If this script exists in your project root, it runs when creating or resuming an environment (before the REPL starts).
 
 **Example for an iOS project:**
 ```bash
@@ -201,5 +244,7 @@ MyProject-bugfix                         bugfix                    ↑3 unpushed
 - Base repos in `~/code` should not have dashes in their names (dashes indicate feature clones)
 - Each feature gets a fresh clone, so changes are isolated
 - Claude Code sessions are per-directory, so `--resume` works per feature
+- Codex restore uses `codex resume --last`
+- REPL switching captures terminal context into `.para-llm/handoff.md`; exact hidden session state is not portable between products
 - Unpushed commits are detected before deletion to prevent data loss
 - Project hooks are optional - environments work fine without them

--- a/install.sh
+++ b/install.sh
@@ -98,6 +98,11 @@ fi
 # Derive ENVS_DIR
 ENVS_DIR="$PARA_LLM_ROOT/envs"
 
+CLAUDE_LAUNCH_ARGS="${CLAUDE_LAUNCH_ARGS:---permission-mode auto}"
+CODEX_LAUNCH_ARGS="${CODEX_LAUNCH_ARGS:-}"
+PARA_LLM_DEFAULT_REPL="${PARA_LLM_DEFAULT_REPL:-claude}"
+echo ""
+
 # Create directory structure
 mkdir -p "$PARA_LLM_ROOT"
 mkdir -p "$ENVS_DIR"
@@ -123,6 +128,11 @@ echo "CODE_DIR=\"$CODE_DIR\"" >> "$PARA_LLM_ROOT/config"
 echo "" >> "$PARA_LLM_ROOT/config"
 echo "# Directory where para-llm-directory is installed (source scripts)" >> "$PARA_LLM_ROOT/config"
 echo "INSTALL_DIR=\"$SCRIPT_DIR\"" >> "$PARA_LLM_ROOT/config"
+echo "" >> "$PARA_LLM_ROOT/config"
+echo "# REPL launch profiles and default per-env REPL" >> "$PARA_LLM_ROOT/config"
+echo "PARA_LLM_DEFAULT_REPL=\"$PARA_LLM_DEFAULT_REPL\"" >> "$PARA_LLM_ROOT/config"
+echo "CLAUDE_LAUNCH_ARGS=\"$CLAUDE_LAUNCH_ARGS\"" >> "$PARA_LLM_ROOT/config"
+echo "CODEX_LAUNCH_ARGS=\"$CODEX_LAUNCH_ARGS\"" >> "$PARA_LLM_ROOT/config"
 cat >> "$PARA_LLM_ROOT/config" << 'EOF'
 
 # tmux status line settings
@@ -132,65 +142,53 @@ STATUS_LINE_EMOJI=0
 # STATUS_LINE_PREFIX="Claude"
 EOF
 
-# --- Optional: Speech-to-text plugin ---
-STT_ENABLED=false
-if [[ "$NON_INTERACTIVE" == true ]]; then
-    echo "Skipping STT plugin (non-interactive mode)"
+# --- Always-on voice layer ---
+echo ""
+echo "Setting up voice input/output..."
+echo "  STT: Ctrl+b a records and transcribes with whisper.cpp"
+echo "  TTS: Ctrl+b p speaks/stops latest pane output with Microsoft edge-tts"
+
+# Check/install sox
+if ! command -v rec &>/dev/null; then
+    echo "  Installing sox (audio recording)..."
+    pkg_install sox 2>/dev/null || echo "  Warning: Failed to install sox. Install with your package manager."
 else
-    echo ""
-    echo "Optional: Speech-to-text (STT) plugin"
-    echo "  Adds Ctrl+b a to dictate into the active pane using whisper.cpp"
-    echo "  Runs fully offline - no API keys or cloud calls"
-    echo ""
-    echo "  Dependencies (installed via your package manager):"
-    echo "    sox          ~3 MB   (audio recording)"
-    echo "    whisper-cpp  ~5 MB   (speech recognition engine)"
-    echo "    whisper model ~142 MB (ggml-base.en, auto-downloaded on first use)"
-    echo ""
-    read -r -p "Install STT plugin? [y/N]: " stt_choice
-    if [[ "$stt_choice" =~ ^[Yy] ]]; then
-        STT_ENABLED=true
-    fi
+    echo "  sox already installed"
 fi
 
-if [[ "$STT_ENABLED" == true ]]; then
-    echo ""
-    echo "Setting up STT plugin..."
+# Check/install whisper-cpp
+if ! command -v whisper-cli &>/dev/null && ! command -v whisper-cpp &>/dev/null; then
+    echo "  Installing whisper-cpp (speech recognition)..."
+    pkg_install whisper-cpp 2>/dev/null || echo "  Warning: Failed to install whisper-cpp. Install with your package manager."
+else
+    echo "  whisper-cpp already installed"
+fi
 
-    # Check/install sox
-    if ! command -v rec &>/dev/null; then
-        echo "  Installing sox (audio recording)..."
-        pkg_install sox 2>/dev/null || echo "  Warning: Failed to install sox. Install with your package manager."
-    else
-        echo "  sox already installed"
-    fi
+echo "  Whisper model (~142 MB) will be auto-downloaded on first use"
 
-    # Check/install whisper-cpp
-    if ! command -v whisper-cli &>/dev/null && ! command -v whisper-cpp &>/dev/null; then
-        echo "  Installing whisper-cpp (speech recognition)..."
-        pkg_install whisper-cpp 2>/dev/null || echo "  Warning: Failed to install whisper-cpp. Install with your package manager."
-    else
-        echo "  whisper-cpp already installed"
-    fi
+if ! command -v edge-tts &>/dev/null; then
+    echo "  Warning: edge-tts not found. Install with: pipx install edge-tts"
+else
+    echo "  edge-tts already installed"
+fi
 
-    echo "  Whisper model (~142 MB) will be auto-downloaded on first use"
+cat >> "$PARA_LLM_ROOT/config" << 'EOF'
 
-    # Save STT config
-    cat >> "$PARA_LLM_ROOT/config" << 'EOF'
-
-# Speech-to-text settings
+# Voice settings
 STT_ENABLED=1
+TTS_ENABLED=1
+TTS_AMBIENT_SOUND_ENABLED=1
+TTS_AMBIENT_SOUND_INTERVAL="1"
+TTS_AMBIENT_SOUND="/System/Library/Sounds/Tink.aiff"
+TTS_VOICE="en-US-AndrewNeural"
+TTS_RATE="+0%"
+TTS_VOLUME="+0%"
+TTS_PITCH="+0Hz"
+TTS_SUMMARIZE=1
+TTS_SUMMARIZER_BACKEND="auto"
 # STT_LANGUAGE="en"
 # STT_MODEL_PATH=""  # Override model location (default: $PARA_LLM_ROOT/plugins/stt/models/ggml-base.en.bin)
 EOF
-    echo "  STT plugin enabled (Ctrl+b a)"
-else
-    cat >> "$PARA_LLM_ROOT/config" << 'EOF'
-
-# Speech-to-text settings (disabled - re-run install.sh to enable)
-STT_ENABLED=0
-EOF
-fi
 
 # Add remote save config
 cat >> "$PARA_LLM_ROOT/config" << 'EOF'
@@ -205,6 +203,7 @@ echo "  Bootstrap pointer: $BOOTSTRAP_FILE"
 echo "  Config: $PARA_LLM_ROOT/config"
 echo "  Base repos: $CODE_DIR"
 echo "  Environments: $ENVS_DIR"
+echo "  Default REPL: $PARA_LLM_DEFAULT_REPL"
 echo ""
 
 # Check for fzf
@@ -219,6 +218,7 @@ chmod +x "$SCRIPT_DIR/tmux-cleanup-branch.sh"
 chmod +x "$SCRIPT_DIR/envs.sh"
 chmod +x "$SCRIPT_DIR/tmux-command-center.sh"
 chmod +x "$SCRIPT_DIR/tmux-cc-hooks.sh"
+chmod +x "$SCRIPT_DIR/tmux-repl-selector.sh"
 chmod +x "$SCRIPT_DIR/para-llm-config.sh"
 
 # Make plugin scripts executable (including helper scripts)
@@ -228,6 +228,9 @@ if [[ -d "$SCRIPT_DIR/plugins/claude-state-monitor" ]]; then
 fi
 if [[ -d "$SCRIPT_DIR/plugins/stt" ]]; then
     chmod +x "$SCRIPT_DIR/plugins/stt/"*.sh 2>/dev/null || true
+fi
+if [[ -d "$SCRIPT_DIR/plugins/tts" ]]; then
+    chmod +x "$SCRIPT_DIR/plugins/tts/"*.sh 2>/dev/null || true
 fi
 if [[ -d "$SCRIPT_DIR/plugins/remote-save" ]]; then
     chmod +x "$SCRIPT_DIR/plugins/remote-save/"*.sh 2>/dev/null || true
@@ -244,6 +247,8 @@ cp "$SCRIPT_DIR/scripts/para-llm-restore.sh" "$PARA_LLM_ROOT/scripts/"
 cp "$SCRIPT_DIR/scripts/para-llm-recovery-prompt.sh" "$PARA_LLM_ROOT/scripts/"
 cp "$SCRIPT_DIR/scripts/para-llm-do-restore.sh" "$PARA_LLM_ROOT/scripts/"
 cp "$SCRIPT_DIR/scripts/para-llm-do-discard.sh" "$PARA_LLM_ROOT/scripts/"
+cp "$SCRIPT_DIR/scripts/para-llm-upgrade-envs.sh" "$PARA_LLM_ROOT/scripts/"
+cp "$SCRIPT_DIR/para-llm-config.sh" "$PARA_LLM_ROOT/scripts/"
 # Clean up stale scripts that should not be in $PARA_LLM_ROOT/scripts/
 rm -f "$PARA_LLM_ROOT/scripts/tmux-command-center.sh"
 chmod +x "$PARA_LLM_ROOT/scripts/"*.sh
@@ -373,16 +378,15 @@ bind-key b set-window-option synchronize-panes \; display-message "Toggled broad
 # Ctrl+b t: Remote management menu (add/remove/test/toggle remotes)
 bind-key t display-popup -E -w 60% -h 60% "$SCRIPT_DIR/plugins/remote-save/remote-manage.sh"
 
-EOF
-
-# Conditionally add STT binding
-if [[ "$STT_ENABLED" == true ]]; then
-cat >> ~/.tmux.conf << EOF
+# Ctrl+b y: choose/switch Claude Code or Codex for the active worktree
+bind-key y display-popup -E -w 60% -h 50% "$SCRIPT_DIR/tmux-repl-selector.sh '#{pane_id}' '#{pane_current_path}'"
 
 # Ctrl+b a: Toggle speech-to-text recording (press to record, press again to transcribe)
 bind-key a run-shell -b "$SCRIPT_DIR/plugins/stt/toggle-stt.sh"
+
+# Ctrl+b p: Toggle text-to-speech playback for the active pane
+bind-key p run-shell -b "$SCRIPT_DIR/plugins/tts/toggle-tts.sh"
 EOF
-fi
 
 cat >> ~/.tmux.conf << EOF
 
@@ -405,13 +409,6 @@ bind-key r run-shell '$PARA_LLM_ROOT/scripts/para-llm-restore.sh'
 # Appends to existing status-right, preserving user customizations
 set -ga status-right ' #($SCRIPT_DIR/plugins/claude-state-monitor/tmux-status.sh)'
 EOF
-
-# Conditionally add STT status
-if [[ "$STT_ENABLED" == true ]]; then
-cat >> ~/.tmux.conf << EOF
-set -ga status-right ' #($SCRIPT_DIR/plugins/stt/stt-status.sh)'
-EOF
-fi
 
 cat >> ~/.tmux.conf << EOF
 set -g status-interval 5
@@ -454,10 +451,10 @@ echo "  Ctrl+b k  - Cleanup feature branch"
 echo "  Ctrl+b v  - Command Center (tiled view of all envs)"
 echo "  Ctrl+b b  - Toggle broadcast mode (type in all panes)"
 echo "  Ctrl+b t  - Remote management (add/test/toggle remotes)"
-echo "  Ctrl+b r  - Manual restore Claude sessions"
-if [[ "$STT_ENABLED" == true ]]; then
-echo "  Ctrl+b a  - Toggle speech-to-text recording"
-fi
+echo "  Ctrl+b y  - Choose/switch Claude Code or Codex for active worktree"
+echo "  Ctrl+b a  - Voice input: record/transcribe into active pane"
+echo "  Ctrl+b p  - Voice playback: speak/stop latest pane output"
+echo "  Ctrl+b r  - Manual restore managed AI terminal sessions"
 echo ""
 echo "Recovery:"
 echo "  Sessions auto-saved every 1 minute via tmux-continuum"

--- a/para-llm-config.sh
+++ b/para-llm-config.sh
@@ -28,7 +28,144 @@ ENVS_DIR="$PARA_LLM_ROOT/envs"
 # Use defaults if CODE_DIR not set
 CODE_DIR="${CODE_DIR:-$DEFAULT_CODE_DIR}"
 
+# REPL launch profiles. The selected REPL is stored per environment in
+# $ENV_DIR/.para-llm/repl; these args only define each product's native defaults.
+CLAUDE_LAUNCH_ARGS="${CLAUDE_LAUNCH_ARGS:---permission-mode auto}"
+CODEX_LAUNCH_ARGS="${CODEX_LAUNCH_ARGS:-}"
+PARA_LLM_DEFAULT_REPL="${PARA_LLM_DEFAULT_REPL:-claude}"
+
+para_llm_shell_quote() {
+    printf "'%s'" "$(printf "%s" "$1" | sed "s/'/'\\\\''/g")"
+}
+
+para_llm_env_dir_for_path() {
+    local path="${1:-$(pwd)}"
+
+    case "$path" in
+        "$ENVS_DIR"/*)
+            local rel env_name
+            rel="${path#"$ENVS_DIR"/}"
+            env_name="${rel%%/*}"
+            if [[ -n "$env_name" ]]; then
+                echo "$ENVS_DIR/$env_name"
+                return 0
+            fi
+            ;;
+    esac
+
+    return 1
+}
+
+para_llm_meta_dir_for_path() {
+    local path="${1:-$(pwd)}"
+    local env_dir
+
+    if env_dir="$(para_llm_env_dir_for_path "$path")"; then
+        echo "$env_dir/.para-llm"
+        return 0
+    fi
+
+    return 1
+}
+
+para_llm_ensure_meta_for_path() {
+    local path="${1:-$(pwd)}"
+    local repl="${2:-$PARA_LLM_DEFAULT_REPL}"
+    local meta_dir
+
+    if ! meta_dir="$(para_llm_meta_dir_for_path "$path")"; then
+        return 1
+    fi
+
+    mkdir -p "$meta_dir"
+    touch "$meta_dir/transcript.log"
+    if [[ ! -f "$meta_dir/repl" ]]; then
+        printf "%s\n" "$repl" > "$meta_dir/repl"
+    fi
+}
+
+para_llm_repl_for_path() {
+    local path="${1:-$(pwd)}"
+    local meta_dir
+
+    if meta_dir="$(para_llm_meta_dir_for_path "$path")" && [[ -f "$meta_dir/repl" ]]; then
+        head -n 1 "$meta_dir/repl"
+    else
+        echo "$PARA_LLM_DEFAULT_REPL"
+    fi
+}
+
+para_llm_set_repl_for_path() {
+    local path="$1"
+    local repl="$2"
+    local meta_dir
+
+    case "$repl" in
+        claude|codex) ;;
+        *) repl="$PARA_LLM_DEFAULT_REPL" ;;
+    esac
+
+    meta_dir="$(para_llm_meta_dir_for_path "$path")" || return 1
+    mkdir -p "$meta_dir"
+    printf "%s\n" "$repl" > "$meta_dir/repl"
+    touch "$meta_dir/transcript.log"
+}
+
+para_llm_repl_process_pattern() {
+    local repl="$1"
+
+    case "$repl" in
+        codex) echo "codex" ;;
+        claude|*) echo "claude" ;;
+    esac
+}
+
+para_llm_repl_command() {
+    local repl="$1"
+    local resume="${2:-false}"
+    local handoff_prompt="${3:-}"
+
+    case "$repl" in
+        codex)
+            if [[ -n "$handoff_prompt" ]]; then
+                if [[ -n "$CODEX_LAUNCH_ARGS" ]]; then
+                    echo "codex $CODEX_LAUNCH_ARGS $(para_llm_shell_quote "$handoff_prompt")"
+                else
+                    echo "codex $(para_llm_shell_quote "$handoff_prompt")"
+                fi
+            elif [[ "$resume" == "true" ]]; then
+                echo "codex resume --last"
+            elif [[ -n "$CODEX_LAUNCH_ARGS" ]]; then
+                echo "codex $CODEX_LAUNCH_ARGS"
+            else
+                echo "codex"
+            fi
+            ;;
+        claude|*)
+            if [[ -n "$handoff_prompt" ]]; then
+                echo "claude $CLAUDE_LAUNCH_ARGS $(para_llm_shell_quote "$handoff_prompt")"
+            elif [[ "$resume" == "true" ]]; then
+                echo "claude $CLAUDE_LAUNCH_ARGS --resume"
+            else
+                echo "claude $CLAUDE_LAUNCH_ARGS"
+            fi
+            ;;
+    esac
+}
+
+para_llm_repl_command_for_path() {
+    local path="$1"
+    local resume="${2:-false}"
+    local repl
+
+    repl="$(para_llm_repl_for_path "$path")"
+    para_llm_repl_command "$repl" "$resume"
+}
+
 # Export for child processes
 export PARA_LLM_ROOT
 export CODE_DIR
 export ENVS_DIR
+export CLAUDE_LAUNCH_ARGS
+export CODEX_LAUNCH_ARGS
+export PARA_LLM_DEFAULT_REPL

--- a/plugins/remote-save/remote-restore-full.sh
+++ b/plugins/remote-save/remote-restore-full.sh
@@ -4,7 +4,7 @@
 # 2. For each entry: git clone from git_remote
 # 3. git checkout branch
 # 4. Creates tmux window
-# 5. Launches Claude with --dangerously-skip-permissions --resume if it was running
+# 5. Launches the env's selected REPL if it was running
 
 set -u
 
@@ -17,7 +17,10 @@ fi
 PARA_LLM_ROOT="$(cat "$BOOTSTRAP_FILE")"
 
 # Source config
-if [[ -f "$PARA_LLM_ROOT/config" ]]; then
+CONFIG_LOADER="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/para-llm-config.sh"
+if [[ -f "$CONFIG_LOADER" ]]; then
+    source "$CONFIG_LOADER"
+elif [[ -f "$PARA_LLM_ROOT/config" ]]; then
     source "$PARA_LLM_ROOT/config"
 fi
 
@@ -111,15 +114,24 @@ while IFS='|' read -r win_name pane_path project branch had_claude git_remote; d
         continue
     }
 
-    # Launch Claude if it was running
+    # Launch the env's selected REPL if it was running
     if [[ "$had_claude" == "true" ]]; then
-        echo "  Launching Claude..."
+        para_llm_ensure_meta_for_path "$PROJECT_DIR" >/dev/null 2>&1 || true
+        PANE_ID="$(tmux display-message -p -t "$win_name" '#{pane_id}' 2>/dev/null || true)"
+        META_DIR="$(para_llm_meta_dir_for_path "$PROJECT_DIR" 2>/dev/null || true)"
+        if [[ -n "$PANE_ID" && -n "$META_DIR" ]]; then
+            TRANSCRIPT_FILE="$META_DIR/transcript.log"
+            QUOTED_TRANSCRIPT="$(para_llm_shell_quote "$TRANSCRIPT_FILE")"
+            tmux pipe-pane -t "$PANE_ID" -o "cat >> $QUOTED_TRANSCRIPT" 2>/dev/null || true
+        fi
+        REPL="$(para_llm_repl_for_path "$PROJECT_DIR")"
+        echo "  Launching $REPL..."
         # Determine launch command
         SETUP_SCRIPT="$PROJECT_DIR/paraLlm_setup.sh"
         if [[ -f "$SETUP_SCRIPT" ]]; then
-            LAUNCH_CMD="./paraLlm_setup.sh && claude --dangerously-skip-permissions --resume"
+            LAUNCH_CMD="./paraLlm_setup.sh && $(para_llm_repl_command_for_path "$PROJECT_DIR" true)"
         else
-            LAUNCH_CMD="claude --dangerously-skip-permissions --resume"
+            LAUNCH_CMD="$(para_llm_repl_command_for_path "$PROJECT_DIR" true)"
         fi
         tmux send-keys -t "$win_name" "$LAUNCH_CMD" Enter
     fi

--- a/plugins/stt/toggle-stt.sh
+++ b/plugins/stt/toggle-stt.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Toggle speech-to-text recording for the active tmux pane
-# Called by tmux key binding: Ctrl+b x
+# Called by tmux key binding: Ctrl+b a
 #
 # First press:  start recording from microphone
 # Second press: stop recording, transcribe, inject text into pane
@@ -9,7 +9,7 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-STT_DIR="/tmp/claude-stt"
+STT_DIR="/tmp/para-llm-stt"
 PID_FILE="$STT_DIR/recording.pid"
 TARGET_FILE="$STT_DIR/target-pane"
 AUDIO_FILE="$STT_DIR/audio.wav"

--- a/plugins/tts/extract-latest.sh
+++ b/plugins/tts/extract-latest.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# extract-latest.sh - extract speakable recent text from a tmux pane.
+
+set -uo pipefail
+
+PANE_ID="${1:-}"
+if [[ -z "$PANE_ID" ]]; then
+    PANE_ID="$(tmux display-message -p '#{pane_id}' 2>/dev/null)"
+fi
+
+if [[ -z "$PANE_ID" ]]; then
+    exit 1
+fi
+
+tmux capture-pane -t "$PANE_ID" -p -S - 2>/dev/null \
+    | perl -pe 's/\e\[[0-9;?]*[ -\/]*[@-~]//g; s/\r//g' \
+    | sed \
+        -e '/^[[:space:]]*$/d' \
+        -e '/esc to interrupt/d' \
+        -e '/ctrl.*enter/d' \
+        -e '/shift.*tab/d' \
+        -e '/Press enter to continue/d' \
+        -e '/Do you trust the contents of this directory/d' \
+        -e '/Working with untrusted contents/d' \
+        -e '/project-local config, hooks, and exec policies/d' \
+        -e '/^[[:space:]]*[›>]*[[:space:]]*[12]\. \(Yes, continue\|No, quit\)/d' \
+        -e '/^[[:space:]]*[╭╰│]/d' \
+    | tail -n 240

--- a/plugins/tts/summarize-for-speech.sh
+++ b/plugins/tts/summarize-for-speech.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# summarize-for-speech.sh - turn raw terminal text into concise speakable prose.
+
+set -uo pipefail
+
+BACKEND="${1:-auto}"
+INPUT_FILE="${2:?Usage: summarize-for-speech.sh <backend> <input-file> <output-file> [cwd]}"
+OUTPUT_FILE="${3:?Usage: summarize-for-speech.sh <backend> <input-file> <output-file> [cwd]}"
+CWD="${4:-$(pwd)}"
+
+if [[ ! -s "$INPUT_FILE" ]]; then
+    exit 1
+fi
+
+PROMPT_FILE="$(mktemp "${TMPDIR:-/tmp}/para-llm-tts-summary.XXXXXX")"
+trap 'rm -f "$PROMPT_FILE"' EXIT
+
+cat > "$PROMPT_FILE" <<'PROMPT_EOF'
+Prepare this terminal/chat text for text-to-speech as a smart spoken briefing.
+
+Rules:
+- Return only speakable prose.
+- First identify recent turn boundaries: human/user turns and assistant/model turns.
+- Treat the latest human/user turn as an endpoint. The target to speak is the assistant/model response that follows that human turn.
+- If multiple assistant/model turns appear after the latest human turn, speak the most recent substantive one.
+- If the capture ends with a new human input, unfinished prompt, or command line and there is no assistant/model response after it, look back to the previous completed assistant/model turn.
+- Ignore user input, shell prompts, command prompts, trust dialogs, menus, status bars, keybinding hints, progress indicators, and unfinished input boxes.
+- If the latest visible lines are only terminal UI or an input prompt, look earlier for the most recent substantive assistant/model response.
+- If there is no assistant/model response, summarize the latest substantive terminal command result.
+- Preserve the important meaning of that latest response or result.
+- Do not read code, diffs, stack traces, JSON, tables, or logs verbatim.
+- For diffs, summarize the intent of the change, the implementation approach, the likely behavior impact, and any notable risks or follow-up work.
+- For large code/text blocks, explain what changed, what failed, or what matters rather than reading structure or syntax.
+- Mention file names, command names, errors, and next actions when they are important.
+- Be comprehensive about decisions, results, risks, and next steps.
+- Be concise in phrasing, but do not make it artificially short.
+- Prefer a clear narrative over bullets unless bullets are the most speakable format.
+
+Terminal text:
+PROMPT_EOF
+cat "$INPUT_FILE" >> "$PROMPT_FILE"
+
+run_claude() {
+    command -v claude >/dev/null 2>&1 || return 1
+    (cd "$CWD" && claude -p --no-session-persistence --output-format text < "$PROMPT_FILE") > "$OUTPUT_FILE"
+}
+
+run_codex() {
+    command -v codex >/dev/null 2>&1 || return 1
+    (cd "$CWD" && codex exec --skip-git-repo-check --sandbox read-only --output-last-message "$OUTPUT_FILE" - < "$PROMPT_FILE") >/dev/null
+}
+
+case "$BACKEND" in
+    claude)
+        run_claude
+        ;;
+    codex)
+        run_codex
+        ;;
+    auto|*)
+        run_codex || run_claude
+        ;;
+esac
+
+[[ -s "$OUTPUT_FILE" ]]

--- a/plugins/tts/toggle-tts.sh
+++ b/plugins/tts/toggle-tts.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Toggle text-to-speech playback for the active tmux pane.
+# Called by tmux key binding: Ctrl+b p
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TTS_DIR="/tmp/para-llm-tts"
+mkdir -p "$TTS_DIR"
+
+BOOTSTRAP_FILE="$HOME/.para-llm-root"
+if [[ -f "$BOOTSTRAP_FILE" ]]; then
+    PARA_LLM_ROOT="$(cat "$BOOTSTRAP_FILE")"
+    if [[ -f "$PARA_LLM_ROOT/config" ]]; then
+        source "$PARA_LLM_ROOT/config"
+    fi
+fi
+
+CONFIG_LOADER="$SCRIPT_DIR/../../para-llm-config.sh"
+if [[ -f "$CONFIG_LOADER" ]]; then
+    source "$CONFIG_LOADER"
+fi
+
+TTS_VOICE="${TTS_VOICE:-en-US-AndrewNeural}"
+TTS_RATE="${TTS_RATE:-+0%}"
+TTS_VOLUME="${TTS_VOLUME:-+0%}"
+TTS_PITCH="${TTS_PITCH:-+0Hz}"
+TTS_SUMMARIZE="${TTS_SUMMARIZE:-1}"
+TTS_SUMMARIZER_BACKEND="${TTS_SUMMARIZER_BACKEND:-auto}"
+
+PANE_ID="$(tmux display-message -p '#{pane_id}' 2>/dev/null)"
+PANE_PATH="$(tmux display-message -p -t "$PANE_ID" '#{pane_current_path}' 2>/dev/null || pwd)"
+SAFE_PANE_ID="${PANE_ID#%}"
+PID_FILE="$TTS_DIR/$SAFE_PANE_ID.pid"
+PREP_PID_FILE="$TTS_DIR/$SAFE_PANE_ID.prep.pid"
+AMBIENT_PID_FILE="$TTS_DIR/$SAFE_PANE_ID.ambient.pid"
+TEXT_FILE="$TTS_DIR/$SAFE_PANE_ID.txt"
+SPEECH_FILE="$TTS_DIR/$SAFE_PANE_ID.speech.txt"
+AUDIO_FILE="$TTS_DIR/$SAFE_PANE_ID.mp3"
+
+TTS_AMBIENT_SOUND_ENABLED="${TTS_AMBIENT_SOUND_ENABLED:-1}"
+TTS_AMBIENT_SOUND_INTERVAL="${TTS_AMBIENT_SOUND_INTERVAL:-1}"
+TTS_AMBIENT_SOUND="${TTS_AMBIENT_SOUND:-/System/Library/Sounds/Tink.aiff}"
+
+is_playing() {
+    if [[ -f "$PID_FILE" ]]; then
+        local pid
+        pid="$(cat "$PID_FILE" 2>/dev/null)"
+        if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+            return 0
+        fi
+        rm -f "$PID_FILE"
+    fi
+    if [[ -f "$PREP_PID_FILE" ]]; then
+        local prep_pid
+        prep_pid="$(cat "$PREP_PID_FILE" 2>/dev/null)"
+        if [[ -n "$prep_pid" ]] && kill -0 "$prep_pid" 2>/dev/null; then
+            return 0
+        fi
+        rm -f "$PREP_PID_FILE"
+    fi
+    if [[ -f "$AMBIENT_PID_FILE" ]]; then
+        local ambient_pid
+        ambient_pid="$(cat "$AMBIENT_PID_FILE" 2>/dev/null)"
+        if [[ -n "$ambient_pid" ]] && kill -0 "$ambient_pid" 2>/dev/null; then
+            return 0
+        fi
+        rm -f "$AMBIENT_PID_FILE"
+    fi
+    return 1
+}
+
+stop_playback() {
+    local pid prep_pid
+    pid="$(cat "$PID_FILE" 2>/dev/null || true)"
+    if [[ -n "$pid" ]]; then
+        kill "$pid" 2>/dev/null || true
+    fi
+    prep_pid="$(cat "$PREP_PID_FILE" 2>/dev/null || true)"
+    if [[ -n "$prep_pid" && "$prep_pid" != "$$" ]]; then
+        kill "$prep_pid" 2>/dev/null || true
+    fi
+    rm -f "$PID_FILE"
+    rm -f "$PREP_PID_FILE"
+    rm -f "$AUDIO_FILE"
+    stop_ambient_loop
+    tmux display-message "TTS stopped"
+}
+
+stop_ambient_loop() {
+    local ambient_pid
+    ambient_pid="$(cat "$AMBIENT_PID_FILE" 2>/dev/null || true)"
+    if [[ -n "$ambient_pid" ]]; then
+        kill "$ambient_pid" 2>/dev/null || true
+    fi
+    rm -f "$AMBIENT_PID_FILE"
+}
+
+cleanup_on_exit() {
+    stop_ambient_loop
+    rm -f "$PREP_PID_FILE"
+}
+trap cleanup_on_exit EXIT TERM INT
+
+start_ambient_loop() {
+    if [[ "$TTS_AMBIENT_SOUND_ENABLED" == "0" ]]; then
+        return 0
+    fi
+    if ! command -v afplay >/dev/null 2>&1 || [[ ! -f "$TTS_AMBIENT_SOUND" ]]; then
+        return 0
+    fi
+
+    stop_ambient_loop
+    (
+        while true; do
+            afplay "$TTS_AMBIENT_SOUND" >/dev/null 2>&1 || true
+            sleep "$TTS_AMBIENT_SOUND_INTERVAL"
+        done
+    ) &
+    echo "$!" > "$AMBIENT_PID_FILE"
+}
+
+start_playback() {
+    echo "$$" > "$PREP_PID_FILE"
+
+    if ! command -v edge-tts >/dev/null 2>&1; then
+        tmux display-message "TTS Error: edge-tts not found. Install with: pipx install edge-tts"
+        exit 1
+    fi
+    if ! command -v afplay >/dev/null 2>&1; then
+        tmux display-message "TTS Error: afplay not found"
+        exit 1
+    fi
+
+    "$SCRIPT_DIR/extract-latest.sh" "$PANE_ID" > "$TEXT_FILE"
+    if [[ ! -s "$TEXT_FILE" ]]; then
+        tmux display-message "TTS: no readable pane text found"
+        exit 1
+    fi
+
+    start_ambient_loop
+    cp "$TEXT_FILE" "$SPEECH_FILE"
+    if [[ "$TTS_SUMMARIZE" != "0" ]]; then
+        local backend="$TTS_SUMMARIZER_BACKEND"
+        if [[ "$backend" == "auto" && "$(type -t para_llm_repl_for_path 2>/dev/null)" == "function" ]]; then
+            backend="$(para_llm_repl_for_path "$PANE_PATH" 2>/dev/null || echo "auto")"
+        fi
+        tmux display-message "TTS preparing speech text..."
+        if ! "$SCRIPT_DIR/summarize-for-speech.sh" "$backend" "$TEXT_FILE" "$SPEECH_FILE" "$PANE_PATH" >/dev/null 2>&1; then
+            cp "$TEXT_FILE" "$SPEECH_FILE"
+            tmux display-message "TTS summary unavailable; using pane text"
+        fi
+    fi
+
+    rm -f "$AUDIO_FILE"
+    tmux display-message "TTS generating audio..."
+    if ! edge-tts \
+        --file "$SPEECH_FILE" \
+        --voice "$TTS_VOICE" \
+        --rate "$TTS_RATE" \
+        --volume "$TTS_VOLUME" \
+        --pitch "$TTS_PITCH" \
+        --write-media "$AUDIO_FILE" >/dev/null 2>&1; then
+        stop_ambient_loop
+        tmux display-message "TTS Error: edge-tts failed"
+        rm -f "$AUDIO_FILE"
+        exit 1
+    fi
+
+    stop_ambient_loop
+    afplay "$AUDIO_FILE" &
+    local pid=$!
+    echo "$pid" > "$PID_FILE"
+    rm -f "$PREP_PID_FILE"
+    tmux display-message "TTS playing latest pane output (Ctrl+b p to stop)"
+}
+
+if is_playing; then
+    stop_playback
+else
+    start_playback
+fi

--- a/scripts/para-llm-do-restore.sh
+++ b/scripts/para-llm-do-restore.sh
@@ -26,11 +26,11 @@ fi
 # Wait for panes to initialize
 sleep 2
 
-# Re-launch Claude sessions
-tmux display-message "para-llm: Re-launching Claude sessions..."
+# Re-launch managed AI terminal sessions
+tmux display-message "para-llm: Re-launching managed AI terminal sessions..."
 "$PARA_LLM_ROOT/scripts/para-llm-restore.sh"
 
-# Open command center view after Claude sessions are launched
+# Open command center view after managed AI terminal sessions are launched
 COMMAND_CENTER_SCRIPT="${INSTALL_DIR:-}/tmux-command-center.sh"
 if [[ -n "${INSTALL_DIR:-}" && -x "$COMMAND_CENTER_SCRIPT" ]]; then
     sleep 1

--- a/scripts/para-llm-restore.sh
+++ b/scripts/para-llm-restore.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# para-llm-restore.sh - Re-launch Claude in restored panes
+# para-llm-restore.sh - Re-launch managed AI terminals in restored panes
 # Idempotent: checks that pane is idle before launching
 
 set -u
@@ -12,6 +12,13 @@ if [[ ! -f "$BOOTSTRAP_FILE" ]]; then
 fi
 PARA_LLM_ROOT="$(cat "$BOOTSTRAP_FILE")"
 ENVS_DIR="$PARA_LLM_ROOT/envs"
+
+CONFIG_LOADER="$PARA_LLM_ROOT/scripts/para-llm-config.sh"
+if [[ -f "$CONFIG_LOADER" ]]; then
+    source "$CONFIG_LOADER"
+elif [[ -f "$PARA_LLM_ROOT/config" ]]; then
+    source "$PARA_LLM_ROOT/config"
+fi
 
 STATE_FILE="$PARA_LLM_ROOT/recovery/session-state"
 LOG_FILE="$PARA_LLM_ROOT/recovery/restore.log"
@@ -38,8 +45,8 @@ while IFS='|' read -r win_name pane_path project branch had_claude git_remote; d
 done < "$STATE_FILE"
 
 if [[ ${#SAVED_ENTRIES[@]} -eq 0 ]]; then
-    echo "  No Claude sessions to restore" >> "$LOG_FILE"
-    tmux display-message "para-llm: No Claude sessions to restore"
+    echo "  No managed AI terminal sessions to restore" >> "$LOG_FILE"
+    tmux display-message "para-llm: No managed AI terminal sessions to restore"
     exit 0
 fi
 
@@ -81,7 +88,7 @@ BRANCH=$branch
 CWD=$pane_path
 MAPPING_EOF
 
-        # Set initial pane title (will show until Claude hooks update it)
+        # Set initial pane title (will show until hooks update it)
         tmux set-option -p -t "$pane_id" @pane_display "#[fg=yellow]Working | $project | $branch#[default]" 2>/dev/null || true
 
         # Set initial border color to yellow (starting)
@@ -89,10 +96,17 @@ MAPPING_EOF
 
         # Determine launch command
         SETUP_SCRIPT="$pane_path/paraLlm_setup.sh"
+        para_llm_ensure_meta_for_path "$pane_path" >/dev/null 2>&1 || true
+        META_DIR="$(para_llm_meta_dir_for_path "$pane_path" 2>/dev/null || true)"
+        if [[ -n "$META_DIR" ]]; then
+            TRANSCRIPT_FILE="$META_DIR/transcript.log"
+            QUOTED_TRANSCRIPT="$(para_llm_shell_quote "$TRANSCRIPT_FILE")"
+            tmux pipe-pane -t "$pane_id" -o "cat >> $QUOTED_TRANSCRIPT" 2>/dev/null || true
+        fi
         if [[ -f "$SETUP_SCRIPT" ]]; then
-            LAUNCH_CMD="./paraLlm_setup.sh && claude --dangerously-skip-permissions --resume"
+            LAUNCH_CMD="./paraLlm_setup.sh && $(para_llm_repl_command_for_path "$pane_path" true)"
         else
-            LAUNCH_CMD="claude --dangerously-skip-permissions --resume"
+            LAUNCH_CMD="$(para_llm_repl_command_for_path "$pane_path" true)"
         fi
 
         # Send command to the pane
@@ -106,4 +120,4 @@ MAPPING_EOF
 done < <(tmux list-panes -a -F '#{pane_id}|#{pane_current_path}|#{pane_pid}' 2>/dev/null)
 
 echo "  Summary: restored=$RESTORED skipped=$SKIPPED" >> "$LOG_FILE"
-tmux display-message "para-llm: Restored $RESTORED Claude session(s), skipped $SKIPPED"
+tmux display-message "para-llm: Restored $RESTORED managed AI terminal session(s), skipped $SKIPPED"

--- a/scripts/para-llm-save-state.sh
+++ b/scripts/para-llm-save-state.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# para-llm-save-state.sh - Save Claude session state for recovery
+# para-llm-save-state.sh - Save managed AI terminal session state for recovery
 # Called by tmux-resurrect's @resurrect-hook-post-save-all (every 1 minute via continuum)
 
 set -u
@@ -12,7 +12,10 @@ fi
 PARA_LLM_ROOT="$(cat "$BOOTSTRAP_FILE")"
 
 # Source config for INSTALL_DIR and other settings
-if [[ -f "$PARA_LLM_ROOT/config" ]]; then
+CONFIG_LOADER="$PARA_LLM_ROOT/scripts/para-llm-config.sh"
+if [[ -f "$CONFIG_LOADER" ]]; then
+    source "$CONFIG_LOADER"
+elif [[ -f "$PARA_LLM_ROOT/config" ]]; then
     source "$PARA_LLM_ROOT/config"
 fi
 
@@ -85,9 +88,11 @@ SESSION_NAME=$(echo "$PANE_DATA" | head -1 | cut -d'|' -f1)
                     # Branch is env_name with project prefix removed
                     BRANCH="${ENV_NAME#"$PROJECT"-}"
 
-                    # Check if Claude is running in this pane
+                    # Check if the env's selected AI terminal is running in this pane
                     HAD_CLAUDE="false"
-                    if pgrep -P "$pane_pid" -f "claude" >/dev/null 2>&1; then
+                    para_llm_ensure_meta_for_path "$pane_path" >/dev/null 2>&1 || true
+                    REPL="$(para_llm_repl_for_path "$pane_path" 2>/dev/null || echo "claude")"
+                    if pgrep -P "$pane_pid" -f "$(para_llm_repl_process_pattern "$REPL")" >/dev/null 2>&1; then
                         HAD_CLAUDE="true"
                     fi
 

--- a/scripts/para-llm-upgrade-envs.sh
+++ b/scripts/para-llm-upgrade-envs.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# para-llm-upgrade-envs.sh - add para-llm metadata to existing envs/worktrees.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ -f "$SCRIPT_DIR/../para-llm-config.sh" ]]; then
+    source "$SCRIPT_DIR/../para-llm-config.sh"
+elif [[ -f "$SCRIPT_DIR/para-llm-config.sh" ]]; then
+    source "$SCRIPT_DIR/para-llm-config.sh"
+else
+    BOOTSTRAP_FILE="$HOME/.para-llm-root"
+    if [[ -f "$BOOTSTRAP_FILE" ]]; then
+        PARA_LLM_ROOT="$(cat "$BOOTSTRAP_FILE")"
+        source "$PARA_LLM_ROOT/config"
+        ENVS_DIR="$PARA_LLM_ROOT/envs"
+    else
+        echo "para-llm: no config found" >&2
+        exit 1
+    fi
+fi
+
+DEFAULT_REPL="${1:-$PARA_LLM_DEFAULT_REPL}"
+case "$DEFAULT_REPL" in
+    claude|codex) ;;
+    *) DEFAULT_REPL="$PARA_LLM_DEFAULT_REPL" ;;
+esac
+
+if [[ ! -d "$ENVS_DIR" ]]; then
+    echo "No envs directory found at $ENVS_DIR"
+    exit 0
+fi
+
+upgrade_env() {
+    local env_dir="$1"
+    local meta_dir="$env_dir/.para-llm"
+    local status="upgraded"
+
+    mkdir -p "$meta_dir"
+    touch "$meta_dir/transcript.log"
+
+    if [[ -f "$meta_dir/repl" ]]; then
+        status="already configured"
+    else
+        printf "%s\n" "$DEFAULT_REPL" > "$meta_dir/repl"
+    fi
+
+    if [[ -f "$env_dir/CLAUDE.md" && ! -f "$env_dir/AGENTS.md" ]]; then
+        cp "$env_dir/CLAUDE.md" "$env_dir/AGENTS.md"
+    fi
+
+    printf "%s|%s\n" "$status" "$env_dir"
+}
+
+attach_transcript_pipe() {
+    command -v tmux >/dev/null 2>&1 || return 0
+    tmux list-panes -a -F '#{pane_id}|#{pane_current_path}' 2>/dev/null | while IFS='|' read -r pane_id pane_path; do
+        case "$pane_path" in
+            "$ENVS_DIR"/*)
+                local env_dir meta_dir transcript_file quoted_transcript
+                env_dir="$(para_llm_env_dir_for_path "$pane_path" 2>/dev/null || true)"
+                [[ -n "$env_dir" ]] || continue
+                meta_dir="$env_dir/.para-llm"
+                mkdir -p "$meta_dir"
+                transcript_file="$meta_dir/transcript.log"
+                touch "$transcript_file"
+                quoted_transcript="$(para_llm_shell_quote "$transcript_file")"
+                tmux pipe-pane -t "$pane_id" -o "cat >> $quoted_transcript" 2>/dev/null || true
+                ;;
+        esac
+    done
+}
+
+UPGRADED=0
+ALREADY=0
+while IFS= read -r env_dir; do
+    [[ -d "$env_dir" ]] || continue
+    result="$(upgrade_env "$env_dir")"
+    status="${result%%|*}"
+    path="${result#*|}"
+    case "$status" in
+        "already configured") ALREADY=$((ALREADY + 1)) ;;
+        *) UPGRADED=$((UPGRADED + 1)) ;;
+    esac
+    echo "$status: $path"
+done < <(find "$ENVS_DIR" -mindepth 1 -maxdepth 1 -type d | sort)
+
+attach_transcript_pipe
+
+echo "Summary: upgraded=$UPGRADED already_configured=$ALREADY"

--- a/tmux-new-branch.sh
+++ b/tmux-new-branch.sh
@@ -12,6 +12,7 @@ mkdir -p "$ENVS_DIR"
 
 # Check if we're currently in command center (matches cleanup script approach)
 COMMAND_CENTER="command-center"
+CREATED_PANE_ID=""
 
 in_command_center() {
     local current_window
@@ -33,6 +34,7 @@ create_feature_window() {
         tmux new-window -n "$branch_name" -c "$working_dir"
         local new_pane_id
         new_pane_id=$(tmux display-message -p '#{pane_id}')
+        CREATED_PANE_ID="$new_pane_id"
 
         # Add to state file so it can be restored later
         local session_name
@@ -47,7 +49,7 @@ create_feature_window() {
         tmux select-layout -t "$COMMAND_CENTER" tiled
 
         # Initialize pane display option
-        tmux set-option -p -t "$new_pane_id" @pane_display "#[fg=green]No Claude | $project_name | $branch_name#[default]" 2>/dev/null || true
+        tmux set-option -p -t "$new_pane_id" @pane_display "#[fg=green]No AI terminal | $project_name | $branch_name#[default]" 2>/dev/null || true
 
         # Start state monitor for the new pane
         local monitor_script
@@ -61,10 +63,62 @@ create_feature_window() {
     else
         # Normal mode - just create window
         tmux new-window -n "$branch_name" -c "$working_dir"
+        CREATED_PANE_ID=$(tmux display-message -p '#{pane_id}')
     fi
 }
 
-# Create CLAUDE.md for multi-repo environments
+select_repl_for_env() {
+    local env_dir="$1"
+    local default_repl="${2:-$PARA_LLM_DEFAULT_REPL}"
+
+    if command -v fzf >/dev/null 2>&1; then
+        local selection
+        selection=$(printf "Claude Code\nCodex\n" | fzf --prompt="REPL for $(basename "$env_dir") [$default_repl]> ")
+        case "$selection" in
+            "Codex") echo "codex" ;;
+            "Claude Code"|*) echo "claude" ;;
+        esac
+    else
+        echo "Select REPL for $(basename "$env_dir"):"
+        echo "1) Claude Code"
+        echo "2) Codex"
+        read -r -p "Choice [1]: " choice
+        case "$choice" in
+            2) echo "codex" ;;
+            *) echo "claude" ;;
+        esac
+    fi
+}
+
+start_transcript_pipe() {
+    local pane_id="$1"
+    local working_dir="$2"
+    local meta_dir transcript_file quoted_transcript
+
+    para_llm_ensure_meta_for_path "$working_dir" >/dev/null 2>&1 || return 0
+    meta_dir="$(para_llm_meta_dir_for_path "$working_dir" 2>/dev/null || true)"
+    [[ -n "$meta_dir" ]] || return 0
+    transcript_file="$meta_dir/transcript.log"
+    quoted_transcript="$(para_llm_shell_quote "$transcript_file")"
+    tmux pipe-pane -t "$pane_id" -o "cat >> $quoted_transcript" 2>/dev/null || true
+}
+
+launch_repl_in_created_pane() {
+    local working_dir="$1"
+    local resume="${2:-false}"
+    local launch_cmd
+
+    start_transcript_pipe "$CREATED_PANE_ID" "$working_dir"
+    launch_cmd="$(para_llm_repl_command_for_path "$working_dir" "$resume")"
+
+    if [[ -f "$working_dir/paraLlm_setup.sh" ]]; then
+        tmux send-keys -t "$CREATED_PANE_ID" "./paraLlm_setup.sh && $launch_cmd" Enter
+    else
+        tmux send-keys -t "$CREATED_PANE_ID" "$launch_cmd" Enter
+    fi
+}
+
+# Create AI-agent instructions for multi-repo environments
 # Usage: create_multi_repo_claude_md "/path/to/env" "branch-name" "repo1" "repo2" ...
 create_multi_repo_claude_md() {
     local env_dir="$1"
@@ -112,6 +166,8 @@ CLAUDE_MD_EOF
 - If repos depend on each other, merge the dependency first
 - Consider using feature flags if changes can't be deployed atomically
 CLAUDE_MD_EOF
+
+    cp "$env_dir/CLAUDE.md" "$env_dir/AGENTS.md"
 }
 
 # Find git repos in ~/code (base repos only - directories with .git dir at top level)
@@ -311,8 +367,9 @@ main() {
                     ENV_DIR="${ENVS_DIR}/${selected_env}"
                     PROJECT_NAME="$selected_env"
                     local window_name="${PROJECT_NAME} multi-repo (${REPO_COUNT})"
+                    para_llm_ensure_meta_for_path "$ENV_DIR" >/dev/null 2>&1 || true
                     create_feature_window "$window_name" "$ENV_DIR"
-                    tmux send-keys "claude --dangerously-skip-permissions --resume" Enter
+                    launch_repl_in_created_pane "$ENV_DIR" true
                     exit 0
                 else
                     # Step 3a: Select existing branch for this project
@@ -328,12 +385,8 @@ main() {
                     CLONE_DIR="${ENV_DIR}/${REPO_NAME}"
 
                     create_feature_window "$BRANCH_NAME" "$CLONE_DIR"
-                    # Run setup hook if it exists
-                    if [[ -f "$CLONE_DIR/paraLlm_setup.sh" ]]; then
-                        tmux send-keys "./paraLlm_setup.sh && claude --dangerously-skip-permissions --resume" Enter
-                    else
-                        tmux send-keys "claude --dangerously-skip-permissions --resume" Enter
-                    fi
+                    para_llm_ensure_meta_for_path "$CLONE_DIR" >/dev/null 2>&1 || true
+                    launch_repl_in_created_pane "$CLONE_DIR" true
                     exit 0
                 fi
                 ;;
@@ -398,19 +451,19 @@ main() {
 
                 # For multi-repo, start in env root; for single repo, start in the repo
                 if [[ "$IS_MULTI_REPO" == true ]]; then
-                    # Create CLAUDE.md explaining multi-repo context
+                    # Create AI-agent instructions explaining multi-repo context
                     create_multi_repo_claude_md "$ENV_DIR" "$BRANCH_NAME" "${REPO_NAMES[@]}"
                     local window_name="${PROJECT_NAME} multi-repo (${REPO_COUNT})"
+                    SELECTED_REPL="$(select_repl_for_env "$ENV_DIR")"
+                    para_llm_set_repl_for_path "$ENV_DIR" "$SELECTED_REPL"
                     create_feature_window "$window_name" "$ENV_DIR"
-                    tmux send-keys "claude --dangerously-skip-permissions" Enter
+                    launch_repl_in_created_pane "$ENV_DIR" false
                 else
                     CLONE_DIR="$primary_clone_dir"
+                    SELECTED_REPL="$(select_repl_for_env "$ENV_DIR")"
+                    para_llm_set_repl_for_path "$CLONE_DIR" "$SELECTED_REPL"
                     create_feature_window "$BRANCH_NAME" "$CLONE_DIR"
-                    if [[ -f "$CLONE_DIR/paraLlm_setup.sh" ]]; then
-                        tmux send-keys "./paraLlm_setup.sh && claude --dangerously-skip-permissions" Enter
-                    else
-                        tmux send-keys "claude --dangerously-skip-permissions" Enter
-                    fi
+                    launch_repl_in_created_pane "$CLONE_DIR" false
                 fi
                 exit 0
                 ;;
@@ -448,16 +501,14 @@ main() {
                     sleep 1
                     if [[ "$IS_MULTI_REPO" == true ]]; then
                         local window_name="${PROJECT_NAME} multi-repo (${REPO_COUNT})"
+                        para_llm_ensure_meta_for_path "$ENV_DIR" >/dev/null 2>&1 || true
                         create_feature_window "$window_name" "$ENV_DIR"
-                        tmux send-keys "claude --dangerously-skip-permissions --resume" Enter
+                        launch_repl_in_created_pane "$ENV_DIR" true
                     else
                         CLONE_DIR="${ENV_DIR}/${REPO_NAME}"
+                        para_llm_ensure_meta_for_path "$CLONE_DIR" >/dev/null 2>&1 || true
                         create_feature_window "$BRANCH_NAME" "$CLONE_DIR"
-                        if [[ -f "$CLONE_DIR/paraLlm_setup.sh" ]]; then
-                            tmux send-keys "./paraLlm_setup.sh && claude --dangerously-skip-permissions --resume" Enter
-                        else
-                            tmux send-keys "claude --dangerously-skip-permissions --resume" Enter
-                        fi
+                        launch_repl_in_created_pane "$CLONE_DIR" true
                     fi
                     exit 0
                 fi
@@ -508,19 +559,19 @@ main() {
 
                 # For multi-repo, start in env root; for single repo, start in the repo
                 if [[ "$IS_MULTI_REPO" == true ]]; then
-                    # Create CLAUDE.md explaining multi-repo context
+                    # Create AI-agent instructions explaining multi-repo context
                     create_multi_repo_claude_md "$ENV_DIR" "$BRANCH_NAME" "${REPO_NAMES[@]}"
                     local window_name="${PROJECT_NAME} multi-repo (${REPO_COUNT})"
+                    SELECTED_REPL="$(select_repl_for_env "$ENV_DIR")"
+                    para_llm_set_repl_for_path "$ENV_DIR" "$SELECTED_REPL"
                     create_feature_window "$window_name" "$ENV_DIR"
-                    tmux send-keys "claude --dangerously-skip-permissions" Enter
+                    launch_repl_in_created_pane "$ENV_DIR" false
                 else
                     CLONE_DIR="$primary_clone_dir"
+                    SELECTED_REPL="$(select_repl_for_env "$ENV_DIR")"
+                    para_llm_set_repl_for_path "$CLONE_DIR" "$SELECTED_REPL"
                     create_feature_window "$BRANCH_NAME" "$CLONE_DIR"
-                    if [[ -f "$CLONE_DIR/paraLlm_setup.sh" ]]; then
-                        tmux send-keys "./paraLlm_setup.sh && claude --dangerously-skip-permissions" Enter
-                    else
-                        tmux send-keys "claude --dangerously-skip-permissions" Enter
-                    fi
+                    launch_repl_in_created_pane "$CLONE_DIR" false
                 fi
                 exit 0
                 ;;

--- a/tmux-repl-selector.sh
+++ b/tmux-repl-selector.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# tmux-repl-selector.sh - choose/switch the AI REPL for an existing env pane.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/para-llm-config.sh"
+
+TARGET_PANE="${1:-}"
+TARGET_PATH="${2:-}"
+
+if [[ -z "$TARGET_PANE" ]]; then
+    TARGET_PANE="$(tmux display-message -p '#{pane_id}' 2>/dev/null)"
+fi
+if [[ -z "$TARGET_PATH" ]]; then
+    TARGET_PATH="$(tmux display-message -p -t "$TARGET_PANE" '#{pane_current_path}' 2>/dev/null)"
+fi
+
+if [[ -z "$TARGET_PANE" || -z "$TARGET_PATH" ]]; then
+    tmux display-message "REPL selector: unable to determine target pane"
+    exit 1
+fi
+
+ENV_DIR="$(para_llm_env_dir_for_path "$TARGET_PATH" 2>/dev/null || true)"
+if [[ -z "$ENV_DIR" ]]; then
+    tmux display-message "REPL selector: active pane is not under $ENVS_DIR"
+    exit 1
+fi
+
+para_llm_ensure_meta_for_path "$TARGET_PATH" >/dev/null 2>&1 || true
+META_DIR="$ENV_DIR/.para-llm"
+TRANSCRIPT_FILE="$META_DIR/transcript.log"
+HANDOFF_FILE="$META_DIR/handoff.md"
+CURRENT_REPL="$(para_llm_repl_for_path "$TARGET_PATH")"
+
+choose_repl() {
+    if command -v fzf >/dev/null 2>&1; then
+        printf "Claude Code\nCodex\n" | fzf --prompt="REPL for $(basename "$ENV_DIR") [$CURRENT_REPL]> "
+    else
+        echo "Select REPL:"
+        echo "1) Claude Code"
+        echo "2) Codex"
+        read -r -p "Choice [1]: " choice
+        case "$choice" in
+            2) echo "Codex" ;;
+            *) echo "Claude Code" ;;
+        esac
+    fi
+}
+
+strip_control_sequences() {
+    perl -pe 's/\e\[[0-9;?]*[ -\/]*[@-~]//g; s/\r//g' 2>/dev/null || cat
+}
+
+capture_transcript() {
+    mkdir -p "$META_DIR"
+    {
+        echo ""
+        echo "===== capture $(date -u +"%Y-%m-%dT%H:%M:%SZ") from $TARGET_PANE ====="
+        tmux capture-pane -t "$TARGET_PANE" -p -S - 2>/dev/null
+    } >> "$TRANSCRIPT_FILE"
+}
+
+write_handoff() {
+    local from_repl="$1"
+    local to_repl="$2"
+    local clean_tail
+
+    clean_tail="$(tail -n 260 "$TRANSCRIPT_FILE" 2>/dev/null | strip_control_sequences | sed '/^[[:space:]]*$/d' | tail -n 180)"
+
+    {
+        echo "# para-llm handoff"
+        echo ""
+        echo "- From: $from_repl"
+        echo "- To: $to_repl"
+        echo "- Environment: $ENV_DIR"
+        echo "- Working directory: $TARGET_PATH"
+        echo "- Generated: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+        echo ""
+        echo "## Git Status"
+        echo '```'
+        git -C "$TARGET_PATH" status --short --branch 2>/dev/null || true
+        echo '```'
+        echo ""
+        echo "## Recent Terminal Transcript"
+        echo '```'
+        printf "%s\n" "$clean_tail"
+        echo '```'
+        echo ""
+        echo "Continue the work from this context. Inspect the repository directly when details are unclear."
+    } > "$HANDOFF_FILE"
+}
+
+start_transcript_pipe() {
+    local quoted_transcript
+    quoted_transcript="$(para_llm_shell_quote "$TRANSCRIPT_FILE")"
+    tmux pipe-pane -t "$TARGET_PANE" -o "cat >> $quoted_transcript" 2>/dev/null || true
+}
+
+selection="$(choose_repl || true)"
+case "$selection" in
+    "Claude Code") SELECTED_REPL="claude" ;;
+    "Codex") SELECTED_REPL="codex" ;;
+    *) exit 0 ;;
+esac
+
+capture_transcript
+para_llm_set_repl_for_path "$TARGET_PATH" "$SELECTED_REPL"
+start_transcript_pipe
+
+HANDOFF_PROMPT=""
+if [[ "$CURRENT_REPL" != "$SELECTED_REPL" ]]; then
+    write_handoff "$CURRENT_REPL" "$SELECTED_REPL"
+    HANDOFF_PROMPT="Read .para-llm/handoff.md and continue the work. Use the repository and tools directly to verify the current state."
+fi
+
+if [[ -n "$HANDOFF_PROMPT" ]]; then
+    LAUNCH_CMD="$(para_llm_repl_command "$SELECTED_REPL" false "$HANDOFF_PROMPT")"
+else
+    LAUNCH_CMD="$(para_llm_repl_command "$SELECTED_REPL" true)"
+fi
+
+tmux respawn-pane -k -t "$TARGET_PANE" -c "$TARGET_PATH" "$LAUNCH_CMD"
+tmux display-message "REPL: switched $(basename "$ENV_DIR") to $SELECTED_REPL"


### PR DESCRIPTION
## Summary
- add per-worktree REPL metadata and a Ctrl+b y selector for switching Claude Code/Codex
- capture terminal transcripts and generate handoff context when switching agents
- make STT always available on Ctrl+b a and add TTS playback on Ctrl+b p
- add an upgrade script for existing envs to create .para-llm metadata and attach transcript logging

## Verification
- bash -n install.sh para-llm-config.sh tmux-new-branch.sh tmux-repl-selector.sh scripts/para-llm-restore.sh scripts/para-llm-save-state.sh scripts/para-llm-do-restore.sh scripts/para-llm-upgrade-envs.sh plugins/remote-save/remote-restore-full.sh plugins/stt/toggle-stt.sh plugins/stt/transcribe.sh plugins/tts/toggle-tts.sh plugins/tts/extract-latest.sh
- git diff --check