### PR TITLE
Add TTS playback indicator + fix STT hallucination

### DIFF
--- a/.llm-context/topics/bugs-fixed.md
+++ b/.llm-context/topics/bugs-fixed.md
@@ -129,6 +129,13 @@ Log of bugs encountered and fixed in the para-llm-directory project. Each entry 
 **Files**: `install.sh:16-37` (new functions), `install.sh:140,148,182` (replaced calls), `plugins/stt/toggle-stt.sh:22,26`, `plugins/stt/transcribe.sh:34`
 **Issue**: #44
 
+### BUG-016: STT (Ctrl+b a) transcribes every recording as "you"
+**Date**: 2026-05-17
+**Symptom**: Every `Ctrl+b a` recording produced the literal string `you` (or sometimes `Thank you.`, `Thanks for watching.`), regardless of what was spoken.
+**Cause**: Two layered issues. (1) The terminal app hosting tmux had no macOS microphone permission, so `rec` connected to CoreAudio successfully but received only silence — the WAV file was full-sized but contained ~0.000015 RMS amplitude (essentially noise floor). (2) Whisper's `ggml-base.en` model has a strong prior to emit "you" / "thank you" / "thanks for watching" when fed silent audio (a well-known artifact of its YouTube training data). The 1000-byte file-size floor in `toggle-stt.sh` only catches near-instantaneous taps; it does not catch silent-but-long recordings.
+**Fix**: Three guardrails. (1) `toggle-stt.sh` now runs `sox <wav> -n stat` before invoking the transcriber and rejects audio with RMS below 0.003 with the message `STT: no audible audio (RMS=...; check mic permission for your terminal app)`. (2) `rec` stderr now goes to `/tmp/para-llm-stt/rec.log` instead of `/dev/null` so silent-failure modes leave a trail. (3) `transcribe.sh` filters known Whisper hallucination strings (case-insensitive, terminal-punctuation tolerant): `you`, `thank you`, `thank you for watching`, `thanks for watching`, `thanks`, `bye`, `[blank_audio]`, `(silence)`. The filter only matches whole-transcript equality so real speech containing the word "you" passes through. User-side remediation: enable mic permission for the terminal app in System Settings → Privacy & Security → Microphone and relaunch the terminal.
+**File**: `plugins/stt/toggle-stt.sh:58-78`, `plugins/stt/transcribe.sh:66-83`
+
 ---
 
 ## Known Bug-Prone Areas

--- a/.llm-context/topics/product-features.md
+++ b/.llm-context/topics/product-features.md
@@ -147,6 +147,16 @@ The currently selected pane is marked with asterisks (handled by tmux `pane-bord
 | **Needs Action: Permission** | Cyan | Claude needs permission approval |
 | **No Claude** | Green | Git pane with no Claude session running |
 | **No Git** | Default | Pane not in a git repository |
+| **♪ \<any state\>** | Magenta | TTS playback (or prep) active for this pane — overrides base color |
+
+**TTS playback indicator**: When `Ctrl+b p` triggers playback in a pane, the
+border + label switch to magenta with a `♪` prefix until playback finishes or
+is stopped. Only one pane can play at a time — starting playback in a second
+pane stops the first and "steals" the slot (a `TTS: stole playback from pane
+%N` message is shown). The slot is tracked at `/tmp/para-llm-tts/active.pane`
+and lifecycle is owned by `plugins/tts/toggle-tts.sh`. The indicator is
+written by both `state-detector.sh` (polling) and the Claude state hook
+(`state-tracker.sh`) so neither path strips it between events.
 
 **Detection Method** (terminal-based, simple & reliable):
 

--- a/plugins/claude-state-monitor/hooks/state-tracker.sh
+++ b/plugins/claude-state-monitor/hooks/state-tracker.sh
@@ -166,6 +166,22 @@ MAPEOF
             LABEL="$LABEL: $DETAIL"
         fi
 
+        # If TTS playback (or prep) is live for this pane, force magenta + ♪.
+        # Otherwise a Claude state event would clobber the indicator set by
+        # state-detector between its 300ms polls.
+        TTS_DIR="/tmp/para-llm-tts"
+        PANE_SAFE="${PANE_ID#%}"
+        for tts_file in "$TTS_DIR/$PANE_SAFE.pid" "$TTS_DIR/$PANE_SAFE.prep.pid"; do
+            if [[ -f "$tts_file" ]]; then
+                TTS_PID=$(cat "$tts_file" 2>/dev/null || echo "")
+                if [[ -n "$TTS_PID" ]] && kill -0 "$TTS_PID" 2>/dev/null; then
+                    COLOR="magenta"
+                    LABEL="♪ $LABEL"
+                    break
+                fi
+            fi
+        done
+
         # Update tmux border style directly
         if [[ "$COLOR" != "default" ]]; then
             tmux set-option -p -t "$PANE_ID" pane-border-style "fg=$COLOR" 2>/dev/null || true

--- a/plugins/claude-state-monitor/state-detector.sh
+++ b/plugins/claude-state-monitor/state-detector.sh
@@ -23,6 +23,7 @@ BRANCH="${3:-unknown}"
 # Configuration
 POLL_INTERVAL=0.3                         # Fast polling for responsive updates
 PANE_MAPPING_DIR="/tmp/claude-pane-mapping"
+TTS_DIR="/tmp/para-llm-tts"
 
 # Find PARA_LLM_ROOT via bootstrap file for persistent storage
 BOOTSTRAP_FILE="$HOME/.para-llm-root"
@@ -119,14 +120,32 @@ is_claude_session() {
     return 1
 }
 
-# Detect state for this pane
+# Check if TTS playback (or prep) is live for this pane
+is_tts_playing() {
+    local safe="${PANE_ID#%}"
+    local f pid
+    for f in "$TTS_DIR/$safe.pid" "$TTS_DIR/$safe.prep.pid"; do
+        if [[ -f "$f" ]]; then
+            pid=$(cat "$f" 2>/dev/null)
+            if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+                return 0
+            fi
+        fi
+    done
+    return 1
+}
+
+# Detect state for this pane. Appends "+tts" when TTS playback is active so
+# the indicator survives unchanged base state (e.g. ready->ready+tts triggers
+# a re-render).
 detect_state() {
+    local base
     if is_claude_session; then
         # Claude session: check if "esc to interrupt" is in the status bar
         if is_claude_working; then
-            echo "working"
+            base="working"
         else
-            echo "ready"
+            base="ready"
         fi
     else
         # Regular terminal: check for running commands
@@ -134,46 +153,56 @@ detect_state() {
         pane_pid=$(get_pane_pid)
 
         if has_child_processes "$pane_pid"; then
-            echo "working"
+            base="working"
         else
-            echo "ready"
+            base="ready"
         fi
+    fi
+
+    if is_tts_playing; then
+        echo "$base+tts"
+    else
+        echo "$base"
     fi
 }
 
-# Update pane border style
+# Update pane border style. TTS active forces magenta over the base color.
 update_border_style() {
     local state="$1"
     local color
 
     case "$state" in
-        ready)   color="$COLOR_READY" ;;
-        working) color="$COLOR_WORKING" ;;
-        *)       color="$COLOR_WORKING" ;;
+        ready*)   color="$COLOR_READY" ;;
+        working*) color="$COLOR_WORKING" ;;
+        *)        color="$COLOR_WORKING" ;;
     esac
+
+    if [[ "$state" == *"+tts" ]]; then
+        color="magenta"
+    fi
 
     tmux set-option -p -t "$PANE_ID" pane-border-style "fg=$color" 2>/dev/null
 }
 
-# Write display string for pane-border-format
+# Write display string for pane-border-format. TTS active prepends ♪ and
+# overrides color to magenta.
 write_display() {
     local state="$1"
-    local color
+    local color label
 
     case "$state" in
-        ready)   color="$COLOR_READY" ;;
-        working) color="$COLOR_WORKING" ;;
-        *)       color="$COLOR_WORKING" ;;
+        ready*)   color="$COLOR_READY"; label="$LABEL_READY" ;;
+        working*) color="$COLOR_WORKING"; label="$LABEL_WORKING" ;;
+        *)        color="$COLOR_WORKING"; label="$LABEL_WORKING" ;;
     esac
 
-    local label
-    case "$state" in
-        ready)   label="$LABEL_READY" ;;
-        working) label="$LABEL_WORKING" ;;
-        *)       label="$LABEL_WORKING" ;;
-    esac
+    local prefix=""
+    if [[ "$state" == *"+tts" ]]; then
+        color="magenta"
+        prefix="♪ "
+    fi
 
-    local display="#[fg=$color]$label | $PROJECT | $BRANCH#[default]"
+    local display="#[fg=$color]${prefix}${label} | $PROJECT | $BRANCH#[default]"
     tmux set-option -p -t "$PANE_ID" @pane_display "$display" 2>/dev/null || true
 }
 

--- a/plugins/stt/toggle-stt.sh
+++ b/plugins/stt/toggle-stt.sh
@@ -55,8 +55,10 @@ start_recording() {
     # Remove old audio file
     rm -f "$AUDIO_FILE"
 
-    # Start recording: 16-bit, mono, 16kHz WAV (whisper.cpp input format)
-    rec -q -b 16 -c 1 -r 16000 "$AUDIO_FILE" &
+    # Start recording: 16-bit, mono, 16kHz WAV (whisper.cpp input format).
+    # Capture rec's stderr so silent-failure modes (denied mic permission, no
+    # default input device, sox driver errors) leave a trail we can read.
+    rec -b 16 -c 1 -r 16000 "$AUDIO_FILE" 2>"$STT_DIR/rec.log" &
     local rec_pid=$!
     echo "$rec_pid" > "$PID_FILE"
 
@@ -91,6 +93,20 @@ stop_and_transcribe() {
         tmux display-message "STT: Recording too short, nothing to transcribe"
         rm -f "$AUDIO_FILE"
         return 1
+    fi
+
+    # Detect silent / near-silent audio before invoking Whisper. Whisper's
+    # ggml-base.en model has a strong prior to emit "you" / "thank you" on
+    # silent input, so without this guard a denied mic permission looks like
+    # a transcription bug. RMS is on a 0..1 scale; room tone is ~0.001-0.003.
+    if command -v sox &>/dev/null; then
+        local rms
+        rms=$(sox "$AUDIO_FILE" -n stat 2>&1 | awk '/RMS[[:space:]]+amplitude/ {print $NF; exit}')
+        if [[ -n "$rms" ]] && awk -v r="$rms" 'BEGIN { exit !(r+0 < 0.003) }'; then
+            tmux display-message "STT: no audible audio (RMS=$rms; check mic permission for your terminal app)"
+            rm -f "$AUDIO_FILE"
+            return 1
+        fi
     fi
 
     tmux display-message "Transcribing..."

--- a/plugins/stt/transcribe.sh
+++ b/plugins/stt/transcribe.sh
@@ -65,6 +65,24 @@ OUTPUT=$("$WHISPER_BIN" \
 # Clean up: strip leading/trailing whitespace and blank lines
 CLEANED=$(echo "$OUTPUT" | sed '/^$/d' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
 
+# Filter Whisper hallucinations on near-silent input. ggml-base.en is heavily
+# fine-tuned on YouTube data and emits these exact strings when fed silence
+# that slipped past upstream RMS checks. We only filter when the whole
+# transcript is one of these (case-insensitive, trailing punctuation tolerated).
+case "$(echo "$CLEANED" | tr '[:upper:]' '[:lower:]' | sed 's/[.,!?]*$//')" in
+    "you" \
+    | "thank you" \
+    | "thanks for watching" \
+    | "thank you for watching" \
+    | "thanks" \
+    | "bye" \
+    | "[blank_audio]" \
+    | "(silence)")
+        echo "Filtered Whisper hallucination: '$CLEANED'" >&2
+        exit 1
+        ;;
+esac
+
 if [[ -n "$CLEANED" ]]; then
     echo "$CLEANED"
 else

--- a/plugins/tts/toggle-tts.sh
+++ b/plugins/tts/toggle-tts.sh
@@ -37,6 +37,7 @@ AMBIENT_PID_FILE="$TTS_DIR/$SAFE_PANE_ID.ambient.pid"
 TEXT_FILE="$TTS_DIR/$SAFE_PANE_ID.txt"
 SPEECH_FILE="$TTS_DIR/$SAFE_PANE_ID.speech.txt"
 AUDIO_FILE="$TTS_DIR/$SAFE_PANE_ID.mp3"
+ACTIVE_FILE="$TTS_DIR/active.pane"
 
 TTS_AMBIENT_SOUND_ENABLED="${TTS_AMBIENT_SOUND_ENABLED:-1}"
 TTS_AMBIENT_SOUND_INTERVAL="${TTS_AMBIENT_SOUND_INTERVAL:-1}"
@@ -84,7 +85,57 @@ stop_playback() {
     rm -f "$PREP_PID_FILE"
     rm -f "$AUDIO_FILE"
     stop_ambient_loop
+    release_playback_slot
     tmux display-message "TTS stopped"
+}
+
+stop_playback_for_pane() {
+    local safe="$1"
+    [[ -z "$safe" ]] && return 0
+    local p_pid p_prep p_amb pid
+    p_pid="$TTS_DIR/$safe.pid"
+    p_prep="$TTS_DIR/$safe.prep.pid"
+    p_amb="$TTS_DIR/$safe.ambient.pid"
+    if [[ -f "$p_pid" ]]; then
+        pid="$(cat "$p_pid" 2>/dev/null)"
+        [[ -n "$pid" ]] && kill "$pid" 2>/dev/null || true
+        rm -f "$p_pid"
+    fi
+    if [[ -f "$p_prep" ]]; then
+        pid="$(cat "$p_prep" 2>/dev/null)"
+        if [[ -n "$pid" && "$pid" != "$$" ]]; then
+            kill "$pid" 2>/dev/null || true
+        fi
+        rm -f "$p_prep"
+    fi
+    if [[ -f "$p_amb" ]]; then
+        pid="$(cat "$p_amb" 2>/dev/null)"
+        [[ -n "$pid" ]] && kill "$pid" 2>/dev/null || true
+        rm -f "$p_amb"
+    fi
+    rm -f "$TTS_DIR/$safe.mp3"
+}
+
+acquire_playback_slot() {
+    if [[ -f "$ACTIVE_FILE" ]]; then
+        local other
+        other="$(cat "$ACTIVE_FILE" 2>/dev/null)"
+        if [[ -n "$other" && "$other" != "$SAFE_PANE_ID" ]]; then
+            stop_playback_for_pane "$other"
+            tmux display-message "TTS: stole playback from pane %$other"
+        fi
+    fi
+    echo "$SAFE_PANE_ID" > "$ACTIVE_FILE"
+}
+
+release_playback_slot() {
+    if [[ -f "$ACTIVE_FILE" ]]; then
+        local owner
+        owner="$(cat "$ACTIVE_FILE" 2>/dev/null)"
+        if [[ "$owner" == "$SAFE_PANE_ID" ]]; then
+            rm -f "$ACTIVE_FILE"
+        fi
+    fi
 }
 
 stop_ambient_loop() {
@@ -99,6 +150,10 @@ stop_ambient_loop() {
 cleanup_on_exit() {
     stop_ambient_loop
     rm -f "$PREP_PID_FILE"
+    if [[ ! -f "$PID_FILE" ]]; then
+        # No live playback handed off — give up the slot so another pane can claim it.
+        release_playback_slot
+    fi
 }
 trap cleanup_on_exit EXIT TERM INT
 
@@ -121,6 +176,7 @@ start_ambient_loop() {
 }
 
 start_playback() {
+    acquire_playback_slot
     echo "$$" > "$PREP_PID_FILE"
 
     if ! command -v edge-tts >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- **TTS playback indicator + single-slot lock** (73801b3): Mark the currently-playing pane with a magenta border + ♪ prefix so it's visually unambiguous which Claude pane is being read aloud. Only one pane can play at a time — starting playback in a second pane stops the first and steals the global slot tracked at `/tmp/para-llm-tts/active.pane`. Both writers (state-detector polling and the Claude state hook) check the TTS PID files so the indicator survives Claude state-change events between 300ms polls.
- **STT "you" hallucination fix** (1e75cd5): When the terminal app lacks macOS mic permission, `rec` silently captures zeros and Whisper's `ggml-base.en` hallucinates "you" / "thank you for watching" on silence. Added three guardrails: RMS check via `sox stat` before transcribing (rejects below 0.003 with a message pointing at mic permission), `rec` stderr captured to `rec.log`, and a whole-transcript hallucination filter for the canonical Whisper-on-silence outputs.

## Test plan
- [ ] `Ctrl+b p` in pane A turns the border magenta with `♪` prefix during prep and playback
- [ ] `Ctrl+b p` in pane B while A is playing stops A within 300ms and starts B (status message: "TTS: stole playback from pane %N")
- [ ] `Ctrl+b p` in the playing pane stops playback and clears the indicator within 300ms
- [ ] If start_playback fails (e.g. missing edge-tts), the active.pane slot is released by the EXIT trap
- [ ] `Ctrl+b a` with mic permission denied shows `STT: no audible audio (RMS=...; check mic permission for your terminal app)` instead of injecting "you"
- [ ] `Ctrl+b a` with mic permission granted produces real transcription
- [ ] `rec` failure modes (no default input, sox error) leave a readable trace in `/tmp/para-llm-stt/rec.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)