### PR TITLE
Speak mode: make Ctrl+b o work on Codex panes

### DIFF
--- a/.llm-context/topics/bugs-fixed.md
+++ b/.llm-context/topics/bugs-fixed.md
@@ -303,6 +303,15 @@ Log of bugs encountered and fixed in the para-llm-directory project. Each entry 
 
 ---
 
+### BUG-039: Ctrl+b o "doesn't work well" on Codex panes
+**Date**: 2026-08-10
+**Symptom**: Speak mode on a Codex pane misbehaved — little/no live narration, a recap about the wrong session, no working heartbeat.
+**Cause**: Three Codex-specific gaps in the new speak loop. (1) **Source mis-routing (the big one)** — `for_pane()` chose the adapter by which transcript FOLDER exists: `if ClaudeCodeSource.locate(): return it`. A worktree that ever ran Claude keeps its `~/.claude/projects/<enc-cwd>` dir forever, so a Codex pane there routed to the STALE, ended Claude transcript (last touched days earlier) instead of the live Codex rollout — it tailed a file that never grows (no narration) and recapped the wrong session. (2) **Heartbeat forced off** — `is_working()` reads `hook_state(cwd)` from Claude Code's per-cwd state file; for a Codex pane that file is stale (`"state":"ended"` from the prior Claude session), and `st in ("blocked","ended")` hard-forced the heartbeat off even while Codex was actively working. (3) **Recap degraded** — `recent_events()` was only overridden in `ClaudeCodeSource`, so Codex fell back to the agent-text-only base impl and the turn-aware catch-up couldn't say "you asked X".
+**Fix**: (1) **Route by the running REPL, not folder existence** — new `_repl_in_pane()` walks the pane's process tree (`pane_pid` → descendants) and matches `codex` vs `claude` in the command line (verified signal: `node …/codex` vs `claude …`); `for_pane()` picks the source matching the live REPL even when the other framework left a stale transcript, falling back to folder-existence only when the REPL is indeterminate (raw cwd). (2) **Gate hook_state on source** — `is_working()` only consults `hook_state` when `src.name == "claude"`; Codex relies on the footer, whose "esc to interrupt" text it shares (verified). (3) **`CodexSource.recent_events()`** — interleaves real user `input_text` prompts (skipping `<environment_context>`/`<turn_aborted>` system injections) with agent text. Codex rollouts interleave ~16 noise records per message, so the last two prompts sit ~900 lines deep; the tail floor is raised to 8000 lines so the recap reaches them. Also hardened `turn_context()` (speak_loop): keep every user prompt in full and cap each agent block (1400 chars), truncating from the HEAD-preserving side so a huge Codex turn can't bury the anchoring "You:". Verified end-to-end on a live Codex pane: routes to the rollout, narration extracts, footer→heartbeat tracks real state, and the sonnet recap anchors on the real question with concrete status.
+**File**: `prototype/agent_source.py` (`_repl_in_pane`, `for_pane`, `CodexSource.recent_events`), `prototype/speak_loop.py` (`is_working` source gate, `turn_context` head-preserving cap)
+
+---
+
 ## Known Bug-Prone Areas
 
 ### Live narration starves during long tool-heavy agent turns

--- a/prototype/agent_source.py
+++ b/prototype/agent_source.py
@@ -200,6 +200,53 @@ class CodexSource(AgentSource):
             if isinstance(c, dict) and c.get("type") in ("output_text", "text") and (c.get("text") or "").strip():
                 yield TextChunk(c["text"].strip(), o.get("timestamp", ""), self.name)
 
+    def recent_events(self, n: int = 800) -> "list[tuple[str, str]]":
+        """Interleave real user prompts with agent text so the catch-up recap can
+        anchor on 'you asked X'. Codex user messages are input_text; the XML-ish
+        ones (<environment_context>, <turn_aborted>, …) are system injections, not
+        things the person typed, so they're skipped — the plain-text ones are the
+        real prompts.
+
+        Codex rollouts interleave ~16 noise records (token_count, event_msg,
+        reasoning) per message, so the last couple of user turns sit ~900+ lines
+        deep. A Claude-sized tail (800) never reaches them and the recap loses its
+        anchor — so read a much larger window here."""
+        p = self.locate()
+        if not p:
+            return []
+        n = max(n, 8000)
+        try:
+            raw = subprocess.run(["tail", "-n", str(n), str(p)],
+                                 capture_output=True, text=True, errors="replace").stdout
+        except Exception:
+            return []
+        ev: "list[tuple[str, str]]" = []
+        for line in raw.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                o = json.loads(line)
+            except Exception:
+                continue
+            if o.get("type") != "response_item":
+                continue
+            pl = o.get("payload") or {}
+            if pl.get("type") != "message":
+                continue
+            role = pl.get("role")
+            if role == "assistant":
+                for c in (pl.get("content") or []):
+                    if isinstance(c, dict) and c.get("type") in ("output_text", "text") and (c.get("text") or "").strip():
+                        ev.append(("agent", " ".join(c["text"].split())))
+            elif role == "user":
+                txt = " ".join(c.get("text", "") for c in (pl.get("content") or [])
+                               if isinstance(c, dict) and c.get("type") == "input_text")
+                txt = " ".join(txt.split())
+                if txt and not txt.lstrip().startswith("<"):   # skip <environment_context> etc.
+                    ev.append(("user", txt))
+        return ev
+
 
 class PollingSource(AgentSource):
     """Fallback for REPLs with no transcript: capture-pane + filter + settle.
@@ -228,17 +275,69 @@ def _tmux(pane_id: str, fmt: str) -> str:
         return ""
 
 
+def _repl_in_pane(pane_id: str) -> Optional[str]:
+    """Which REPL is actually RUNNING in this pane — 'claude' or 'codex' — from
+    the pane's process tree. This is authoritative; a transcript folder merely
+    existing is not (a worktree that once ran Claude keeps its
+    ~/.claude/projects/<cwd> dir forever, which would otherwise mis-route a Codex
+    pane to that stale, ended Claude transcript). Returns None if inconclusive."""
+    pane_pid = _tmux(pane_id, "#{pane_pid}")
+    if not pane_pid:
+        return None
+    try:
+        out = subprocess.run(["ps", "-o", "pid=,ppid=,command=", "-ax"],
+                             capture_output=True, text=True, timeout=3).stdout
+    except Exception:
+        return None
+    # Build child lists and walk down from the pane's shell, matching the first
+    # descendant whose command names a known REPL.
+    children: "dict[str, list[tuple[str, str]]]" = {}
+    for line in out.splitlines():
+        parts = line.split(None, 2)
+        if len(parts) < 3:
+            continue
+        pid, ppid, cmd = parts
+        children.setdefault(ppid, []).append((pid, cmd))
+    seen, stack = set(), [pane_pid]
+    while stack:
+        cur = stack.pop()
+        for pid, cmd in children.get(cur, []):
+            if pid in seen:
+                continue
+            seen.add(pid)
+            low = cmd.lower()
+            # word-ish match so a path like /opt/homebrew/bin/codex counts but a
+            # cwd argument mentioning the name does not dominate the decision.
+            if re.search(r"(?:^|/)codex(?:\s|$)", low) or " codex " in f" {low} ":
+                return "codex"
+            if re.search(r"(?:^|/)claude(?:\s|$)", low) or " claude " in f" {low} ":
+                return "claude"
+            stack.append(pid)
+    return None
+
+
 def for_pane(pane_or_cwd: str) -> AgentSource:
-    """Pick the right adapter for a pane id (%N) or a raw cwd. Prefers whichever
-    framework has a live transcript for this cwd; polling only if none does."""
+    """Pick the right adapter for a pane id (%N) or a raw cwd. Chooses by the
+    REPL actually running in the pane; only falls back to transcript-existence
+    when that can't be determined (e.g. a raw cwd with no pane)."""
     if pane_or_cwd.startswith("%"):
         cwd = _tmux(pane_or_cwd, "#{pane_current_path}")
+        repl = _repl_in_pane(pane_or_cwd)
     else:
         cwd = pane_or_cwd
+        repl = None
     cc = ClaudeCodeSource(cwd)
+    cx = CodexSource(cwd)
+    # Authoritative: match the source to the running REPL, even if the OTHER
+    # framework left a stale transcript folder in this worktree.
+    if repl == "codex" and cx.locate():
+        return cx
+    if repl == "claude" and cc.locate():
+        return cc
+    # Inconclusive REPL (raw cwd, or detection failed): fall back to whichever
+    # transcript exists, Claude first (its cwd-keyed lookup is exact).
     if cc.locate():
         return cc
-    cx = CodexSource(cwd)
     if cx.locate():
         return cx
     return PollingSource(pane_or_cwd)

--- a/prototype/speak_loop.py
+++ b/prototype/speak_loop.py
@@ -450,7 +450,12 @@ def run(args) -> None:
     def turn_context(max_turns: int = 2, budget: int = 6000) -> str:
         """The last `max_turns` request/response turns, formatted 'You:'/'Agent:'
         so the recap can anchor on what was actually asked — not just a tail of
-        the agent's last few blocks (which is how the recap 'just sucked')."""
+        the agent's last few blocks (which is how the recap 'just sucked').
+
+        Agent turns can be enormous (Codex especially), so a naive tail-truncation
+        drops the leading 'You:' and loses the anchor. Instead, keep every user
+        prompt in full and cap each agent block, so the recap always sees what was
+        asked plus a representative slice of what the agent did."""
         try:
             events = src.recent_events(800)
         except Exception:
@@ -460,8 +465,16 @@ def run(args) -> None:
         ui = [i for i, (r, _) in enumerate(events) if r == "user"]
         start = ui[-max_turns] if len(ui) >= max_turns else (ui[0] if ui else 0)
         sel = events[start:]
-        s = "\n\n".join(("You: " if r == "user" else "Agent: ") + t for r, t in sel)
-        return s[-budget:] if len(s) > budget else s
+        per_agent = 1400          # cap each agent block; user prompts kept in full
+        parts = []
+        for r, t in sel:
+            if r == "user":
+                parts.append("You: " + t)
+            else:
+                parts.append("Agent: " + (t if len(t) <= per_agent else t[:per_agent] + " …"))
+        s = "\n\n".join(parts)
+        # Final safety cap, but keep the HEAD (the anchoring 'You:'), not the tail.
+        return s if len(s) <= budget else s[:budget] + " …"
 
     def enqueue_prio(text: str, marker: str):
         for c in synth_chunks(despeak(text)):
@@ -607,7 +620,12 @@ def run(args) -> None:
     def is_working() -> bool:
         now = time.time()
         if now - _wk["t"] > 0.7:          # throttle the capture-pane check
-            st = hook_state(cwd) if cwd else None
+            # hook_state reads Claude Code's per-cwd state file. Only trust it for
+            # a Claude pane: a Codex pane in a worktree that once ran Claude finds
+            # a STALE file (e.g. state "ended"), which would wrongly force the
+            # heartbeat off. For Codex, the footer ("esc to interrupt") is the
+            # signal. (BUG: Codex heartbeat silent.)
+            st = hook_state(cwd) if (cwd and src.name == "claude") else None
             _wk["v"] = False if st in ("blocked", "ended") else footer_running(args.target)
             _wk["t"] = now
         return _wk["v"]


### PR DESCRIPTION
`Ctrl+b o` (the tail→rewrite→speak loop) didn't work well on **Codex** panes. Root-caused to three Codex-specific gaps, all verified against a live Codex pane.

## 1. Source mis-routing — the "doesn't work" one
`for_pane()` chose the transcript adapter by which **folder** exists (`if ClaudeCodeSource.locate(): return it`). Any worktree that ever ran Claude keeps its `~/.claude/projects/<cwd>` dir forever, so a Codex pane there routed to the **stale, ended Claude transcript** — a file that never grows (no live narration) and describes the wrong session (bad recap).

**Fix:** `_repl_in_pane()` walks the pane's process tree and routes by the REPL **actually running** (`node …/codex` vs `claude …`), falling back to folder-existence only when the REPL is indeterminate (e.g. a raw cwd).

## 2. Working heartbeat forced off
`is_working()` reads Claude Code's per-cwd `hook_state`; for a Codex pane that file is stale (`"state":"ended"` from a prior Claude session), which hard-forced the "sticks" heartbeat off while Codex was actively working.

**Fix:** only trust `hook_state` for `claude` sources. Codex uses the footer — whose `esc to interrupt` text it shares (verified).

## 3. Catch-up recap degraded
`recent_events()` was Claude-only, so Codex fell back to agent-text-only and the recap couldn't say "you asked X."

**Fix:** `CodexSource.recent_events()` interleaves real user `input_text` prompts (skipping `<environment_context>`/`<turn_aborted>` injections). Codex rollouts bury the last prompts ~900 lines deep under `token_count`/`event_msg` noise, so the tail floor is raised to 8000 lines. `turn_context()` now keeps user prompts whole and caps each agent block (head-preserving) so a huge Codex turn can't bury the anchoring `You:`.

## Verification (live Codex pane)
- Routes to the `.codex` rollout, not the stale Claude transcript.
- Narration extracts and rewrites cleanly.
- `hook_state` was stale `ended` (would silence heartbeat); now Codex uses the footer, which reads working.
- Sonnet recap anchors on the real question with concrete, accurate status.

Details in `.llm-context/topics/bugs-fixed.md` (BUG-039).

🤖 Generated with [Claude Code](https://claude.com/claude-code)