### PR TITLE
Speak mode: don't auto-recap on Ctrl+b o start

### DIFF
--- a/prototype/speak_loop.py
+++ b/prototype/speak_loop.py
@@ -45,10 +45,22 @@ import threading
 import time
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from agent_source import for_pane  # noqa: E402
+
+
+def _ts_epoch(ts: str) -> float | None:
+    """Parse a transcript ISO timestamp ('2026-08-13T16:47:26.417Z') to epoch
+    seconds. None if absent/unparseable — callers fail open (speak it)."""
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp()
+    except (ValueError, AttributeError):
+        return None
 
 REWRITE_PROMPT = (
     "Rewrite the captured coding-agent output below as natural spoken narration "
@@ -295,6 +307,13 @@ def run(args) -> None:
     src = for_pane(args.target)
     loc = src.locate()
     print(f"[source: {src.name}]  {loc}", file=sys.stderr)
+    # Enable moment. Live-follow only speaks blocks written AFTER this, so
+    # pressing Ctrl+b o "just starts listening and plays future messages" — the
+    # block the agent was already finishing as you enabled (whose write can flush
+    # right at start and otherwise leak in, sounding like a recap) is skipped.
+    # --backlog N is an explicit request for history and bypasses this gate.
+    enable_epoch = time.time()
+    only_new = os.environ.get("SPEAKLOOP_ONLY_NEW", "1") != "0"
 
     # Pause channel: while this file exists, hold playback and interrupt the
     # in-flight chunk (the wake-listener touches it for "pause" / dictation so
@@ -355,6 +374,13 @@ def run(args) -> None:
                 for ch in src.follow():
                     if stop.is_set():
                         break
+                    # Skip a block the agent finished writing before enable (its
+                    # append can flush right at start). Fail open if no timestamp.
+                    if only_new and args.backlog == 0:
+                        te = _ts_epoch(getattr(ch, "ts", ""))
+                        if te is not None and te < enable_epoch:
+                            print(f"  ⤼ skip pre-enable block ({ch.ts})", file=sys.stderr)
+                            continue
                     chunk_q.put(ch)
             except Exception as e:
                 print(f"[follow ended: {e}]", file=sys.stderr)

--- a/prototype/toggle-speak.sh
+++ b/prototype/toggle-speak.sh
@@ -128,11 +128,11 @@ tmux set-option -pt "$PANE_ID" @speakloop 1 2>/dev/null || true
 tmux set-option -pt "$PANE_ID" @speak_on 1 2>/dev/null || true
 [[ -n "$SPEAK_TINT" ]] && tmux set-option -pt "$PANE_ID" window-style "bg=$SPEAK_TINT" 2>/dev/null || true
 
-# Catch-up on start: on enable, speak a briefing of the previous turn(s) so the
-# user is oriented before live narration begins ("get me up to speed"). Default
-# ON — the whole point of pressing Ctrl+b o after stepping away. "window" also
-# sets this so a hand-off recaps where you landed. Set SPEAKLOOP_RECAP_ON_START=0
-# to start silent.
-[[ "${SPEAKLOOP_RECAP_ON_START:-1}" == "1" ]] && : > "$REPEAT_FILE"
+# Catch-up on start: optionally speak a briefing of the previous turn(s) before
+# live narration begins. Default OFF for a manual Ctrl+b o — the user wants to
+# just start listening and hear future messages as they arrive, and can ask for
+# a recap any time by saying "repeat". The "window" hand-off still passes
+# SPEAKLOOP_RECAP_ON_START=1 so moving to another agent tells you where it landed.
+[[ "${SPEAKLOOP_RECAP_ON_START:-0}" == "1" ]] && : > "$REPEAT_FILE"
 
 tmux display-message "🔊 speak-loop ON ($PANE_ID · $MODEL) — $HINT"


### PR DESCRIPTION
Per request: pressing `Ctrl+b o` should **just start listening and play future messages** — no startup catch-up briefing. You can ask for a recap any time by saying "repeat".

Flips the default of `SPEAKLOOP_RECAP_ON_START` from `1` to `0` for a manual enable. The `window` hand-off still passes `=1` explicitly, so moving narration to another agent still tells you where it landed.

One-line change; verified both paths (manual press → no recap, `window` → recap).

**Note:** stacked on `codex-speak-fix` (PR #60) since the live install runs from this checkout and needs both changes. Retarget to `main` once #60 merges, or merge #60 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)