### PR TITLE
Speak mode: fix "send" blocked by the mic echo guard

### DIFF
--- a/.llm-context/topics/bugs-fixed.md
+++ b/.llm-context/topics/bugs-fixed.md
@@ -312,6 +312,15 @@ Log of bugs encountered and fixed in the para-llm-directory project. Each entry 
 
 ---
 
+### BUG-040: "send" voice command "really not working"
+**Date**: 2026-08-14
+**Symptom**: Saying "send" did nothing — even repeated many times. Whisper transcribed the "Send." lines fine (confirmed in the wake log), but `do_send` never fired.
+**Cause**: The mic self-echo guard (BUG-037) over-blocked. `speak_loop` published the **last 2 narration chunks** (~40s of text) to `tts.speaking`, and `matches_send` dropped any "send" while that text contained a send-word within a 4s cooldown. The user was watching an agent **build a messaging feature**, so the narration said "send"/"sent" constantly (72× in the session) — meaning "send" was "recently said" almost continuously and the real command was suppressed nearly all the time. Repeats didn't help: the only burst override (`all_words_send && count>=2`) needs multiple send-words in **one** whisper line, but a frustrated "Send. Send. Send." arrives as **separate** one-word lines, each blocked individually.
+**Fix**: (1) **Narrow the guard to what's audible now** — `speak_loop` publishes only the **current** chunk (dropped the 2-deep deque), so a command word blocks only while the chunk actually containing it is playing, not for ~40s of history; echo cooldown cut 4s→2s. (2) **Lone-"send"-twice force** — a real "send" lingers in whisper's window so it lands on ≥2 consecutive reads, while a narration echo is embedded in a sentence (`count>1`) and never counts as *lone*; so two consecutive lone-"send" reads (`SEND_FORCE`, ~0.7–1.4s) fire the command even past the echo guard, without re-enabling sentence-embedded echoes. Verified in simulation: lone "send" fires when the current chunk isn't about sending; when it is, the 2nd consecutive read forces it; a "send" embedded in a narrated sentence never fires. Manual escape hatch unchanged: "pause" → "send" → "play".
+**File**: `prototype/speak_loop.py` (`publish_speaking` current-chunk only), `plugins/stt/wake-listener.sh` (`is_lone_send`, `SEND_FORCE`, `TTS_ECHO_COOLDOWN` 4→2)
+
+---
+
 ## Known Bug-Prone Areas
 
 ### Live narration starves during long tool-heavy agent turns

--- a/plugins/stt/wake-listener.sh
+++ b/plugins/stt/wake-listener.sh
@@ -290,7 +290,10 @@ buzz() { chime "$STT_WAKE_FAIL_SOUND"; }
 # couple chunks, refreshed while afplay runs). We use it two ways: to know TTS is
 # live at all, and to drop a matched command word the narration is speaking.
 TTS_SPEAKING_FILE="$SPOOL/tts.speaking"
-TTS_ECHO_COOLDOWN="${STT_WAKE_ECHO_COOLDOWN:-4}"   # secs a spoken word stays "in the air"
+TTS_ECHO_COOLDOWN="${STT_WAKE_ECHO_COOLDOWN:-2}"   # secs a spoken word stays "in the air"
+                                                   # (short: the guard now reads only the
+                                                   # CURRENT chunk, so it need only cover
+                                                   # whisper's lag, not narration history)
 
 # Seconds since the speaking file was last refreshed (huge if it doesn't exist).
 tts_speaking_age() {
@@ -389,6 +392,20 @@ dict_ended=0
 # the same command must not fire again — otherwise saying "transcribe" starts
 # dictation and its own echo immediately ends it.
 echo_stem=""
+# Was the PREVIOUS line a lone "send"? A real "send" lingers in whisper's window
+# so it lands on >=2 consecutive reads; an echo of narrated "send" is embedded in
+# a sentence (count>1) and never counts as lone. So "lone send twice in a row"
+# forces the command through even when the echo guard would block it (the agent
+# narrating a messaging feature says "send" constantly, false-blocking the real
+# command). See SEND_FORCE below.
+send_lone_prev=0
+
+# True when the line is exactly one word and that word is a send-word.
+is_lone_send() {
+    local c=0 w
+    for w in $1; do c=$((c + 1)); done
+    [[ "$c" -eq 1 ]] && word_is_send "$1"
+}
 
 line_has_stem() {
     local line="$1" stem="$2" w
@@ -965,6 +982,17 @@ while mode_active; do
         # to empty, so the sticks' own feedback does NOT count) means someone is
         # talking — duck the tick so it stops masking the command in the mic.
         [[ -n "$norm_line" ]] && touch "$SPOOL/voice.active" 2>/dev/null || true
+        # Force "send" when a LONE "send" persists across two consecutive reads —
+        # the reliable path past the echo guard when the narration keeps saying
+        # "send" (see send_lone_prev). Only in the listening state; dictation's
+        # own send-end path handles submit there.
+        SEND_FORCE=0
+        if is_lone_send "$norm_line"; then
+            [[ "$send_lone_prev" -eq 1 ]] && SEND_FORCE=1
+            send_lone_prev=1
+        else
+            send_lone_prev=0
+        fi
         # The triggered word has left the window once a line arrives without it
         # (alias-aware: transcribe's "subscribe" echo and send's "sent" echo
         # must also keep the guard armed, or the command re-fires on itself).
@@ -992,8 +1020,9 @@ while mode_active; do
                 do_repeat
                 echo_stem="$DIGEST_STEM"
             elif [[ "$echo_stem" != "$SEND_STEM" ]] \
-                && matches_send "$norm_line"; then
-                log_lifecycle "send trigger: '$line'"
+                && { matches_send "$norm_line" || [[ "$SEND_FORCE" == "1" ]]; }; then
+                [[ "$SEND_FORCE" == "1" ]] && _how=" (forced: lone send x2)" || _how=""
+                log_lifecycle "send trigger: '$line'$_how"
                 do_send
                 echo_stem="$SEND_STEM"
             elif [[ "$echo_stem" != "$DIAGNOSTIC_STEM" ]] \

--- a/prototype/speak_loop.py
+++ b/prototype/speak_loop.py
@@ -570,17 +570,17 @@ def run(args) -> None:
 
     # Mic self-echo guard: the TTS plays through the speakers, the mic hears it,
     # and a magic word in the narration ("window", "send") would actuate. We
-    # publish what we're saying RIGHT NOW to a file the wake-listener reads; it
-    # drops any command word we're currently speaking. Keeping the last couple
-    # chunks covers whisper's detection lag spilling into the next chunk.
+    # publish the text we're saying RIGHT NOW to a file the wake-listener reads;
+    # it drops a command word only while that word is actually audible. Publish
+    # just the CURRENT chunk — keeping older chunks made the guard suppress a
+    # command for ~40s of narration history, which false-blocked common words
+    # like "send" when the agent was building a messaging feature.
     tts_speaking_file = spool_dir / "tts.speaking"
-    recent_spoken: "deque" = deque(maxlen=2)
 
     def publish_speaking(text: str):
-        recent_spoken.append(" ".join(text.split()).lower())
         try:
             spool_dir.mkdir(parents=True, exist_ok=True)
-            tts_speaking_file.write_text(" ".join(recent_spoken))
+            tts_speaking_file.write_text(" ".join(text.split()).lower())
         except OSError:
             pass
 


### PR DESCRIPTION
"Send" wasn't working — even repeated. Whisper heard every "Send." (confirmed in the wake log), but `do_send` never fired.

**Cause:** the mic self-echo guard over-blocked. `speak_loop` published the **last 2 narration chunks** (~40s of text) to `tts.speaking`, and `matches_send` dropped any "send" while that text mentioned sending — within a 4s cooldown. With the agent **building a messaging feature**, the narration said "send"/"sent" **72 times**, so "send" was "recently said" almost continuously. Repeats didn't help: the burst override needs multiple send-words in *one* whisper line, but "Send. Send. Send." arrives as *separate* one-word lines.

**Fix:**
- **Narrow the guard to what's audible now** — publish only the *current* chunk (dropped the 2-deep deque), so a word blocks only while the chunk containing it is actually playing, not for ~40s of history. Cooldown 4s→2s.
- **Lone-"send"-twice force** — a real "send" lingers in whisper's window and lands on ≥2 consecutive reads; a narration echo is embedded in a sentence (`count>1`) and never counts as *lone*. Two consecutive lone-"send" reads fire the command past the echo guard (~0.7–1.4s), without re-enabling sentence-embedded echoes.

Verified in simulation (fires when idle; forces on 2nd read when narration is about sending; never fires on embedded echoes). Manual escape hatch unchanged: "pause" → "send" → "play".

**Note:** stacked on `no-recap-start` (#61) → `codex-speak-fix` (#60) → main, since the live install runs from this checkout and needs all of it. Cleanest to merge the stack in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)